### PR TITLE
Add CLI messages at start and end of every module

### DIFF
--- a/Zonemaster-CLI/lib/Zonemaster/CLI.pm
+++ b/Zonemaster-CLI/lib/Zonemaster/CLI.pm
@@ -257,14 +257,19 @@ sub run {
 
             $self->print_spinner();
 
-            if ($self->progress and $entry->tag eq 'MODULE_VERSION') {
+            if ($self->progress and ($entry->tag eq 'MODULE_VERSION' or $entry->tag eq 'MODULE_ENDED')) {
                 if ($self->time) {
                     printf "%7.2f ", $entry->timestamp;
                 }
                 my $m = $entry->args->{module};
                 $m =~ s/^Zonemaster::Test:://;
                 print " " x 10 if $self->level;
-                printf "Starting module %s.\n", $m;
+                if ($entry->tag eq 'MODULE_VERSION') {
+                    printf "Starting module %s.\n", $m;
+                }
+                else {
+                    printf "Module %s ended.\n", $m;
+                }
             }
 
             $counter{ uc $entry->level } += 1;

--- a/Zonemaster/lib/Zonemaster/Test.pm
+++ b/Zonemaster/lib/Zonemaster/Test.pm
@@ -60,6 +60,7 @@ sub run_all_for {
     );
     _log_dependency_versions();
     @results = Zonemaster::Test::Basic->all( $zone );
+    info( MODULE_ENDED => { module => 'Zonemaster::Test::Basic' } );
 
     if ( Zonemaster::Test::Basic->can_continue( @results ) ) {
         ## no critic (Modules::RequireExplicitInclusion)
@@ -83,6 +84,7 @@ sub run_all_for {
                     push @res, info( MODULE_ERROR => { module => $module, msg => "$err" } );
                 }
             }
+            info( MODULE_ENDED => { module => $module } );
 
             push @results, @res;
         }
@@ -115,6 +117,7 @@ sub run_module {
                 push @res, info( MODULE_ERROR => { module => $module, msg => "$err" } );
             }
         }
+        info( MODULE_ENDED => { module => $module } );
         return @res;
     }
     else {

--- a/Zonemaster/lib/Zonemaster/Translator.pm
+++ b/Zonemaster/lib/Zonemaster/Translator.pm
@@ -86,6 +86,7 @@ sub _system_translation {
         "LOOKUP_ERROR"          => "DNS query to {ns} for {name}/{type}/{class} failed with error: {message}",
         "MODULE_ERROR"          => "Fatal error in {module}: {msg}",
         "MODULE_VERSION"        => "Using module {module} version {version}.",
+        "MODULE_ENDED"          => "Module {module} stopped running.",
         "POLICY_FILE"           => "Policy was read from {name}.",
         "POLICY_DISABLED"       => "The module {name} was disabled by the policy.",
         "UNKNOWN_METHOD"        => "Request to run unknown method {method} in module {module}.",


### PR DESCRIPTION
Adds a message with some marginal utility logged after a test module has finished running, and makes the CLI print messages just before and just after a test module is executed.
