### PR TITLE
Technical maintenance plan divided into four smaller documents

### DIFF
--- a/docs/maintenance/ChangeManagement.md
+++ b/docs/maintenance/ChangeManagement.md
@@ -1,0 +1,111 @@
+# Zonemaster - Change management
+
+## Scope
+The release version 1.0 of the Zonemaster project will be on december 11, 2014. 
+
+This document outlines how the changes during the technical maintenance period
+will be classified and the process to implement these changes.
+
+## Input for change 
+Change requests can come from anywhere such as the users mailinglist, the 
+steering committe or the development team. 
+
+The change requests could be classified into two broad categories:
+	* Minor change
+	* Major change
+
+## Minor change
+The nature of minor change requests are explained in the following subsection: 
+
+###  Bug Fixing
+Any bug fixes, the team or any user discovers should be published in the Github
+issue tracker.
+
+Not all issues in the tracker are bugs, and not all reported bugs are software
+bugs, but can be protocol errors in DNS, or user or documentation errors.
+
+Bug fixes are included in minor releases. See the "Version numbering policy" on
+the management of version numbers for releases.
+
+### Minor Changes
+Minor changes are new features, changes or deprecated functionality that do not
+break backwards compatibility, neither force any user to change or update their
+environment that currently runs the software. 
+
+Minor changes are included in minor releases. See the "Version numbering policy"
+on the management of version numbers for releases.
+
+## Major changes 
+A major change should only be performed when there is an API change or there are
+new major features. Things that might break backwards compatibility, or force
+users to change parts or all of their environment running the software. (In
+relation to the "other" maintenance plain, this has nothing to do with the
+amount of work needed to break backwards compatibility.)
+
+Any change and specification that requires architectural changes creates changes
+in the software architecture and therefore be classified under the category
+"Major change". These architectural changes must be documented and any decision
+to implement the specification is made by the development team with support from 
+the steering committee.
+
+A detailed design can be created once the architecture has been set. This
+is done within the development team. The aim is to describe each component and
+its internal structures.
+
+Major changes are included in major releases. See the "Version numbering policy" on 
+the management of version numbers.
+
+## Decision on whether  or not to include the change during the technical maintenance
+period
+
+As mentioned earlier, change requests can come from anywhere such as the users mailinglist, the steering committe or the development team.
+
+Whatever be the type of change request, it should go through the "Issues
+tracker" in the Github project. All requests should be promptly responded to,
+even if the decision to acknowledge the request is postponed (or) not taken into
+consideration.
+
+Any change should be  approved by the development team, and added to the roadmap and the current set of requirements.
+
+
+## Process to implement the change
+Change requests can come from anywhere such as the users mailinglist, the
+steering committe or the development team. 
+
+### Minor changes
+A "bug  fix" or "minor change" should be added as an issue in Github. Then the
+person corresponding is assigned by the release manager or the person who has
+created the issue. The assigned person should then close the  ticket  within a
+specified time as mentioned in the "Key Performance Indicator" (or) update the bug
+with the time duration on when the bug/minor improvement could be solved (or)
+comments the reason for not able to solve the bug/minor improvement.
+
+### Major changes
+Any new development for Zonemaster must follow the strict process where there
+are formal requirements, specifications for implementing the requirements and
+then any design and architecture fulfilling the specifications, and finally the
+implementation and quality assurance. When all this is performed successully the
+software package is relased using the release process.
+
+#### Requirements
+Formal requirements comes from "some kind of management or governance of the
+project", the team and any users requesting new functionality. Requirements
+should be ranked in importance depending on a number of factors such as
+complexity, amount of work, risk, architectural changes, relevance to the
+product and so on.
+
+New requirements that are acknowledged make it to the roadmap and planned for
+specification and implementation. They are also added to the current set of
+requirements.
+
+#### Specification 
+A set of functional specifications can be derived from the requirements. It does
+not describe the inner workings of the system, but are focusing more on the
+interaction between the system and outside world. The specification is added to
+the current set of specifications.
+
+All specified tests must have a requirement that matches the specification, and
+should also reference any valid standards documents that defines the protocol
+(DNS). All specified functionality should also match any functional
+requirements.
+

--- a/docs/maintenance/OrganisationPlan.md
+++ b/docs/maintenance/OrganisationPlan.md
@@ -1,0 +1,123 @@
+# Zonemaster - Organization plan
+
+## Internal organization 
+
+A number of roles have been identified during the maintenance period :
+
+	* Developers
+	* Code reviewer
+	* Tester for Quality Assurance
+	* Translators
+	* Release manager
+	* Package maintainer
+	* Roadmap owner
+	* Github manager
+	* Mailinglist moderator
+	* Mailinglist owner
+	* Support for questions on Github and mailinglists
+	* Operator of website and ASN lookup service
+	* Content editor, web site
+	* Service manager
+	* Technical manager
+	* Project manager
+
+ToDo explain each roles and attribute roles to concerned person
+
+### Developers
+The developers are responsible for the specifications that implements the
+requirements and that the code follows the specifications.
+
+The developer should run sufficient developer testing to ensure that the functionality
+is complete and the major use cases pass.
+ 
+### Code reviewer
+All code should be reviewed by a developer other than the developer himself. The
+person who is attributed the role of reviewing the code is the "Code reviewer". 
+
+### Tester for Quality Assurance (QA)
+The changes in each release are tested against the requirements and the
+specification.
+
+Ideally a second developer or tester then does manual testing of the features to
+include success and failure cases and corner cases. Any issues found are
+recorded on the Github issue tracker for the development for the original
+developer to fix before re-testing. For major developments a separate testing
+issue may be created.
+
+Regression tests should then also be put in place to cover the functionality.
+
+### Translators
+The initial translations of the software, FAQs, web interfaces and so on, are
+for the English, French and Swedish languages. Any user can contribute new
+languages for addition to the project, but any language added should be a
+complete translation of the current set of strings.
+
+Any new language added to the software requires a person to be responsible for
+that translation. Since strings may change between releases, it is important
+that the new strings will be translated for all the languages.
+
+There might be a need to have somebody to be responsible for translations, and
+that this responsibility includes having personal contacts with the translators.
+This role also has the responsibility for the translation documentation and
+processes.
+
+### Release Manager
+The release managers are responsible for going through the
+Github issue tracker for any new issues and delegate the issue to a responsible
+developer for fixing the problem. The issue should also be prioritized and
+planned for a release. When possible, the full dialogue with the reporter of the
+issue should go into this Github issue.
+
+The Release Manager is responsible for the Release Process and the Relase
+Management Process, and can veto the decision to execute the release.
+
+The release manager could also someteimes play the role of code reviewer.
+
+### Package Maintainer [Do we need this role as part of the internal
+organization?]
+Package maintainers test the package before the release of any final version.
+The RC versions are often tested by the package maintainers, and it is also a
+good way to see that the release are working on the platforms that the software
+is distributed with.
+
+### Roadmap Owner
+The roadmap is a public document in the Github source code tree or wiki.
+
+The Roadmap owner has the responsibility for the roadmap, and decides on the
+content and timing of each release in coordination with project management and
+the developer team.
+
+### Github manager
+ToDo
+
+### Mailinglist moderator
+The moderator of the mailinglists have the responsibility to add and
+remove users on the lists (although the two public lists are open for
+subscription), and to moderate the lists if needed (remove spam and so on).
+
+### Mailinglist owner
+The owner of the mailinglists have the responsibility to add and
+remove users on the lists (although the two public lists are open for
+subscription), and to moderate the lists if needed (remove spam and so on).
+
+### Support for questions on Github and mailinglists
+
+ToDo
+
+### Operator of website and ASN lookup service
+
+ToDo
+
+### Content editor, web site
+
+ToDo
+
+### Service manager
+Service managers activity includes for instance the promotion of Zonemaster in a collaborative way and through multiple channels (dedicated web site, meetings, workshops…)
+during the maintenance cycles;
+
+### Technical manager
+ToDo
+
+### Project manager
+ToDo 

--- a/docs/maintenance/ReleasePlan.md
+++ b/docs/maintenance/ReleasePlan.md
@@ -1,0 +1,49 @@
+# Zonemaster - Release Plan
+
+## Scope
+The release version 1.0 of the Zonemaster project will be on december 11, 2014. 
+The technical maintenance period is fixed for two years until december 2016.
+
+This document outlines the release management process followed during this two
+year period.
+
+## Release features
+	a. Classify the issues from the "issue tracker" based on "minor" and
+"major" changes 
+	b. Identify the level of importance/resource/time available for
+completing the issue
+	c. Prioritize the identified issues based on (b) and include them in
+the respective "release schedule" 
+
+The minor or major features that are part of each release are determined by the
+development team.
+
+## Release schedule
+	a. Minor release schedule (TBD)
+	b. Major release schedule (TBD)
+
+The release schedule is determined by the development team. The release date is announce to the steering committee before "x" weeks. 
+
+### Version numbering policy
+	How to number each release
+
+## Release process
+
+In order to create a release, there are a number of tasks that has to be done in
+the chronological order:
+	* Agree the release type (major/minor) release
+	* Agree under which schedule the release will be done
+	* Announce to the steering committee
+	* Implementation
+	* Updating the documenation
+	* Complete all testing
+	* Code reviews
+	* Run code integrity tools
+	* Quality assurance
+	* Generate the release  
+	* Announce to the public, the features in the release
+	* Translations
+	* Friendly notice to any package maintainers that wants to package the
+	  new version.
+
+#### Explanation of each process (ToDo)

--- a/docs/maintenance/Roadmap.md
+++ b/docs/maintenance/Roadmap.md
@@ -1,0 +1,7 @@
+# Zonemaster - Roadmap
+
+## Scope
+
+
+
+


### PR DESCRIPTION
@pawal separated the technical plan into four different documents, so that it can be referenced by the master document "Service Plan" easily
