### PR TITLE
Specify how to install tarballs in system testing

### DIFF
--- a/docs/internal-documentation/distrib-testing/Debian-Preparation.md
+++ b/docs/internal-documentation/distrib-testing/Debian-Preparation.md
@@ -2,13 +2,25 @@
 
 1. Make a clean installation of Debian.
 
-2. Create a new user.
+2. Update the package database.
+
+   ```sh
+   apt-get update
+   ```
+
+3. Install prerequisites
+
+   ```sh
+   apt-get install cpanminus
+   ```
+
+4. Create a new user.
 
    ```sh
    adduser username
    ```
 
-3. Add user to the sudoer list.
+5. Add user to the sudoer list.
 
    ```sh
    visudo
@@ -16,20 +28,14 @@
 
    Copy the contents of the ‘root’ in 'visudo' and change ‘root’ to ‘username’.
 
-4. Update the package database.
-
-   ```sh
-   apt-get update
-   ```
-
-5. Generate all locales needed by test configurations.
+6. Generate all locales needed by test configurations.
 
    ```sh
    locale-gen C en_US.UTF-8
    dpkg-reconfigure locales
    ```
 
-6. Exit from the root shell.
+7. Exit from the root shell.
 
    ```sh
    exit

--- a/docs/internal-documentation/distrib-testing/FreeBSD-Preparation.md
+++ b/docs/internal-documentation/distrib-testing/FreeBSD-Preparation.md
@@ -10,7 +10,7 @@
 2. Install prerequisites
 
    ```sh
-   pkg install curl sudo
+   pkg install curl sudo p5-App-cpanminus
    ```
 
 3. Create a new user

--- a/docs/internal-documentation/maintenance/SystemTesting.md
+++ b/docs/internal-documentation/maintenance/SystemTesting.md
@@ -59,12 +59,22 @@ The set of configurations must include at least:
    2. Install Zonemaster Engine
       1. Follow the [dependencies](https://github.com/dotse/zonemaster-engine/blob/master/docs/installation.md#dependencies) section of the installation guide to the letter.
       2. Install the preliminary distribution tarball for zonemaster-engine.
+
+         ```sh
+         sudo cpanm Zonemaster-${ENGINE_VERSION}.tar.gz
+         ```
+
       3. Follow the [post-installation sanity check](https://github.com/dotse/zonemaster-engine/blob/master/docs/installation.md#post-installation-sanity-check) section of the installation guide to the letter.
 
    3. Install Zonemaster Backend
       1. Follow the [dependencies](https://github.com/dotse/zonemaster-backend/blob/master/docs/installation.md#dependencies)
          section of the installation guide to the letter.
       2. Install the preliminary distribution tarball for zonemaster-backend.
+
+         ```sh
+         sudo cpanm Zonemaster-WebBackend-${BACKEND_VERSION}.tar.gz
+         ```
+
       3. Follow the [configuration](https://github.com/dotse/zonemaster-backend/blob/master/docs/installation.md#configuration) section of the installation guide to the letter.
       4. Follow the [startup](https://github.com/dotse/zonemaster-backend/blob/master/docs/installation.md#startup) section of the installation guide to the letter.
       5. Follow the [post-installation sanity check](https://github.com/dotse/zonemaster-backend/blob/master/docs/installation.md#post-installation-sanity-check) section of the installation guide to the letter.
@@ -73,6 +83,11 @@ The set of configurations must include at least:
       1. Follow the prerequisites section of [installation.md](https://github.com/dotse/zonemaster-gui/blob/master/docs/installation.md)
          to the letter.
       2. Install the preliminary distribution tarball for zonemaster-backend.
+
+         ```sh
+         sudo cpanm Zonemaster-GUI-${GUI_VERSION}.tar.gz
+         ```
+
       3. Follow the configuration, startup and sanity check sections of [installation.md](https://github.com/dotse/zonemaster-gui/blob/master/docs/installation.md)
          to the letter.
 
@@ -89,6 +104,11 @@ The set of configurations must include at least:
       1. Follow the prerequisites section of [installation.md](https://github.com/dotse/zonemaster-cli/blob/master/docs/installation.md)
          to the letter.
       2. Install the preliminary distribution tarball for zonemaster-backend.
+
+         ```sh
+         sudo cpanm Zonemaster-CLI-${CLI_VERSION}.tar.gz
+         ```
+
       3. Follow the configuration and sanity check sections of [installation.md](https://github.com/dotse/zonemaster-cli/blob/master/docs/installation.md)
          to the letter.
 


### PR DESCRIPTION
I chose the `cpanm` approach because it works. Its only drawback, that I know of, is that it adds another prerequisite to system testing.

Alternatives:

Install using `make` like this:
```sh
tar xzvf ${MODULE}-${MODULE_VERSION}.tar.gz
cd ${MODULE}-${MODULE_VERSION}
perl Makefile.PL
make
sudo make install
```
The problem with the `make` approach is that it doesn't install the dependencies listed in Makefile.PL. I dug up [this link](http://www.dagolden.com/index.php/1528/five-ways-to-install-modules-prereqs-by-hand/) and tried `make installdeps` (on FreeBSD 10.3) but that target doesn't seem to be generated by Makefile.PL.

Install using `cpan` like this:
```sh
tar xzvf ${MODULE}-${MODULE_VERSION}.tar.gz
cd ${MODULE}-${MODULE_VERSION}
sudo cpan .
```
The problem with the `cpan` approach is that it insists on installing "recommended" dependencies and blows up for Backend when MySQL isn't installed.