### PR TITLE
Corrected issue in Markdown heading: Contract or Bug reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ You can follow the project in these two mailinglists:
  * [zonemaster-users](http://lists.iis.se/cgi-bin/mailman/listinfo/zonemaster-users)
  * [zonemaster-devel](http://lists.iis.se/cgi-bin/mailman/listinfo/zonemaster-devel)
 
-### Contact or Bug reporting 
+### Contact or Bug reporting 
 
 For any contacts or bug reporting, please send a mail to
 "contact@zonemaster.net".


### PR DESCRIPTION
The Markdown for the last heading was not rendering correctly, apparently something resembling a space was inserted between the Markdown heading and the actual heading.