### PR TITLE
The backend change log file was renamed

### DIFF
--- a/docs/internal-documentation/maintenance/ReleaseProcess.md
+++ b/docs/internal-documentation/maintenance/ReleaseProcess.md
@@ -19,7 +19,7 @@ Please refer to any Github issues related to the change by the issue number.
  * zonemaster-ldns - [Changes](https://github.com/dotse/zonemaster-ldns/blob/master/Changes)
  * zonemaster-engine - [Changes](https://github.com/dotse/zonemaster-engine/blob/master/Changes)
  * zonemaster-cli - [Changes](https://github.com/dotse/zonemaster-cli/blob/master/Changes)
- * zonemaster-backend - [Changes](https://github.com/dotse/zonemaster-backend/blob/master/CHANGES)
+ * zonemaster-backend - [Changes](https://github.com/dotse/zonemaster-backend/blob/master/Changes)
  * zonemaster-gui - [Changes](https://github.com/dotse/zonemaster-gui/blob/master/Changes)
 
 ## 3. Update prerequisites


### PR DESCRIPTION
I renamed it when updating it for Backend 2.0.0. If that change is accepted, this link needs updating as well.