### PR TITLE
Create dnssec12 placeholder

### DIFF
--- a/docs/specifications/tests/DNSSEC-TP/dnssec12.md
+++ b/docs/specifications/tests/DNSSEC-TP/dnssec12.md
@@ -1,0 +1,43 @@
+## DNSSEC12: Test for DNSSEC Algorithm Completeness
+
+### Test case identifier
+**DNSSEC12** Test for DNSSEC Algorithm Completeness
+
+### Objective
+
+The objectives for this Test Case has yet to be defined. This is a
+placeholder for a complete defintion of the Test Case. The Test Case
+is not yet implemented.
+
+Test for DNSSEC Algorithm Completeness (DS->DNSKEY->RRSIG)
+
+See issues #588, #528, #529 and #231.
+
+### Inputs
+
+TBD.
+
+### Ordered description of steps to be taken to execute the test case
+
+TBD.
+
+### Outcome(s)
+
+TBD.
+
+### Special procedural requirements
+
+TBD.
+
+### Intercase dependencies
+
+TBD.
+
+-------
+
+Copyright (c) 2018, IIS (The Internet Foundation in Sweden)  
+Copyright (c) 2018, AFNIC  
+Creative Commons Attribution 4.0 International License
+
+You should have received a copy of the license along with this
+work.  If not, see <https://creativecommons.org/licenses/by/4.0/>.

--- a/docs/specifications/tests/DNSSEC-TP/dnssec12.md
+++ b/docs/specifications/tests/DNSSEC-TP/dnssec12.md
@@ -11,7 +11,13 @@ is not yet implemented.
 
 Test for DNSSEC Algorithm Completeness (DS->DNSKEY->RRSIG)
 
-See issues #588, #528, #529 and #231.
+See issues [#588], [#528], [#529] and [#231].
+
+[#588]: https://github.com/dotse/zonemaster/issues/588
+[#528]: https://github.com/dotse/zonemaster/issues/528
+[#529]: https://github.com/dotse/zonemaster/issues/529
+[#231]: https://github.com/dotse/zonemaster/issues/231
+
 
 ### Inputs
 


### PR DESCRIPTION
There are links to DNSSEC12 Test Case, but there is no such document. This PR creates a placeholder document to prevent 404 error messages. This PR only partially resolves issue #588, which should be kept open after merge of this PR (if done).