### PR TITLE
Add missing dependency for Debian in Distribution Testing document

### DIFF
--- a/docs/internal/distrib-testing/Debian-build-environment.md
+++ b/docs/internal/distrib-testing/Debian-build-environment.md
@@ -17,7 +17,7 @@ This instruction is for creating it on Debian. See other files for other OSs.
 3. Install prerequisites
 
    ```sh
-   sudo apt-get install git cpanminus gettext autoconf automake build-essential libdevel-checklib-perl libmodule-install-xsutil-perl libssl-dev libidn2-dev libtool
+   sudo apt-get install git cpanminus gettext autoconf automake build-essential libdevel-checklib-perl libmodule-install-xsutil-perl libtest-differences-perl libssl-dev libidn2-dev libtool
    ```
 
 4. Clone 'develop' branch from all Zonemaster repositories


### PR DESCRIPTION
## Purpose

This PR adds a missing dependency in the Debian document for Distribution Testing. It is necessary for the units tests of Zonemaster-LDNS that are run when building.

## Context

Part of 2023.1 release testing.

## Changes

`docs/internal/distrib-testing/Debian-build-environment.md`

- Add missing library `libtest-differences-perl`

## How to test this PR

N/A.
