### PR TITLE
Require ExtUtils::PkgConfig as dependency

### DIFF
--- a/docs/internal/distrib-testing/Debian-build-environment.md
+++ b/docs/internal/distrib-testing/Debian-build-environment.md
@@ -17,7 +17,7 @@ This instruction is for creating it on Debian. See other files for other OSs.
 3. Install prerequisites
 
    ```sh
-   sudo apt-get install git cpanminus gettext autoconf automake build-essential libdevel-checklib-perl libmime-base32-perl libmodule-install-xsutil-perl libtest-differences-perl libssl-dev libidn2-dev libtool
+   sudo apt-get install git cpanminus gettext autoconf automake build-essential libdevel-checklib-perl libextutils-pkgconfig-perl libmime-base32-perl libmodule-install-xsutil-perl libtest-differences-perl libssl-dev libidn2-dev libtool
    ```
 
 4. Clone 'develop' branch from all Zonemaster repositories

--- a/docs/internal/distrib-testing/FreeBSD-build-environment.md
+++ b/docs/internal/distrib-testing/FreeBSD-build-environment.md
@@ -7,7 +7,7 @@ Zonemaster itself.
 This instruction is for creating it on FreeBSD. See other files for other OSs.
 
 
-1. Do a clean installation of latest version of FreeBSD 12
+1. Do a clean installation of latest version of FreeBSD
 
 2. Become root:
 
@@ -62,7 +62,7 @@ This instruction is for creating it on FreeBSD. See other files for other OSs.
 
 9. Install some tools
     ```sh
-    pkg install gmake gettext-tools git-lite p5-Locale-PO p5-App-cpanminus p5-MIME-Base32 p5-Module-Install libtool autoconf automake p5-Devel-CheckLib p5-Module-Install-XSUtil libidn libidn2
+    pkg install gmake gettext-tools git-lite p5-Locale-PO p5-App-cpanminus p5-ExtUtils-PkgConfig p5-MIME-Base32 p5-Module-Install libtool autoconf automake p5-Devel-CheckLib p5-Module-Install-XSUtil libidn libidn2
     ```
 
 10. Install other tools needed, e.g. editor

--- a/docs/internal/distrib-testing/Ubuntu-build-environment.md
+++ b/docs/internal/distrib-testing/Ubuntu-build-environment.md
@@ -31,7 +31,7 @@ needs for testing and releasing Zonemaster:
 3. Install prerequisites (binaries)
 
    ```sh
-   sudo apt-get install cpanminus gettext autoconf automake build-essential libdevel-checklib-perl libmime-base32-perl libmodule-install-xsutil-perl libssl-dev libidn2-dev libtool
+   sudo apt-get install cpanminus gettext autoconf automake build-essential libdevel-checklib-perl libextutils-pkgconfig-perl libmime-base32-perl libmodule-install-xsutil-perl libssl-dev libidn2-dev libtool
    ```
 
 4. Install Docker - *only needed if Docker images are to be built*

--- a/docs/public/installation/zonemaster-engine.md
+++ b/docs/public/installation/zonemaster-engine.md
@@ -39,7 +39,7 @@
 4) Install binary packages:
 
    ```sh
-   sudo dnf --assumeyes install cpanminus gcc libidn2-devel openssl-devel perl-Class-Accessor perl-Clone perl-core perl-Devel-CheckLib perl-Email-Valid perl-File-ShareDir perl-File-Slurp perl-libintl perl-IO-Socket-INET6 perl-List-MoreUtils perl-Mail-SPF perl-Module-Find perl-Module-Install perl-Net-DNS perl-Pod-Coverage perl-Readonly perl-Sub-Override perl-Test-Differences perl-Test-Exception perl-Test-Fatal perl-Test-NoWarnings perl-Test-Pod perl-Text-CSV perl-Test-Simple
+   sudo dnf --assumeyes install cpanminus gcc libidn2-devel openssl-devel perl-Class-Accessor perl-Clone perl-core perl-Devel-CheckLib perl-Email-Valid perl-ExtUtils-PkgConfig perl-File-ShareDir perl-File-Slurp perl-libintl perl-IO-Socket-INET6 perl-List-MoreUtils perl-Mail-SPF perl-Module-Find perl-Module-Install perl-Net-DNS perl-Pod-Coverage perl-Readonly perl-Sub-Override perl-Test-Differences perl-Test-Exception perl-Test-Fatal perl-Test-NoWarnings perl-Test-Pod perl-Text-CSV perl-Test-Simple
    ```
 
 5) Install packages from CPAN:
@@ -88,7 +88,7 @@ Using pre-built packages is the preferred method for Debian and Ubuntu.
 2) Install dependencies from binary packages:
 
    ```sh
-   sudo apt install autoconf automake build-essential cpanminus libclass-accessor-perl libclone-perl libdevel-checklib-perl libemail-valid-perl libfile-sharedir-perl libfile-slurp-perl libidn2-dev libintl-perl libio-socket-inet6-perl liblist-moreutils-perl liblocale-po-perl liblog-any-perl libmail-spf-perl libmime-base32-perl libmodule-find-perl libmodule-install-perl libmodule-install-xsutil-perl libnet-dns-perl libnet-ip-xs-perl libpod-coverage-perl libreadonly-perl libssl-dev libsub-override-perl libtest-differences-perl libtest-exception-perl libtest-fatal-perl libtest-nowarnings-perl libtest-pod-perl libtext-csv-perl libyaml-libyaml-perl libtool m4
+   sudo apt install autoconf automake build-essential cpanminus libclass-accessor-perl libclone-perl libdevel-checklib-perl libemail-valid-perl libextutils-pkgconfig-perl libfile-sharedir-perl libfile-slurp-perl libidn2-dev libintl-perl libio-socket-inet6-perl liblist-moreutils-perl liblocale-po-perl liblog-any-perl libmail-spf-perl libmime-base32-perl libmodule-find-perl libmodule-install-perl libmodule-install-xsutil-perl libnet-dns-perl libnet-ip-xs-perl libpod-coverage-perl libreadonly-perl libssl-dev libsub-override-perl libtest-differences-perl libtest-exception-perl libtest-fatal-perl libtest-nowarnings-perl libtest-pod-perl libtext-csv-perl libyaml-libyaml-perl libtool m4
    ```
 
 3) Install Zonemaster::LDNS and Zonemaster::Engine.
@@ -134,7 +134,7 @@ Using pre-built packages is the preferred method for Debian and Ubuntu.
 5) Install dependencies from binary packages:
 
    ```sh
-   pkg install devel/gmake dns/ldns libidn2 p5-App-cpanminus p5-Class-Accessor p5-Clone p5-Devel-CheckLib p5-Email-Valid p5-File-ShareDir p5-File-Slurp p5-IO-Socket-INET6 p5-List-MoreUtils p5-Locale-libintl p5-Locale-PO p5-Log-Any p5-Mail-SPF p5-MIME-Base32 p5-Module-Find p5-Module-Install p5-Module-Install-XSUtil p5-Net-DNS p5-Net-IP-XS p5-Pod-Coverage p5-Readonly p5-Sub-Override p5-Test-Differences p5-Test-Exception p5-Test-Fatal p5-Test-NoWarnings p5-Test-Pod p5-Text-CSV p5-YAML-LibYAML
+   pkg install devel/gmake dns/ldns libidn2 p5-App-cpanminus p5-Class-Accessor p5-Clone p5-Devel-CheckLib p5-Email-Valid p5-ExtUtils-PkgConfig p5-File-ShareDir p5-File-Slurp p5-IO-Socket-INET6 p5-List-MoreUtils p5-Locale-libintl p5-Locale-PO p5-Log-Any p5-Mail-SPF p5-MIME-Base32 p5-Module-Find p5-Module-Install p5-Module-Install-XSUtil p5-Net-DNS p5-Net-IP-XS p5-Pod-Coverage p5-Readonly p5-Sub-Override p5-Test-Differences p5-Test-Exception p5-Test-Fatal p5-Test-NoWarnings p5-Test-Pod p5-Text-CSV p5-YAML-LibYAML
    ```
 
 6) Install Zonemaster::LDNS:


### PR DESCRIPTION
## Purpose

This PR updates the documentation so that `ExtUtils::PkgConfig` is installed as a prerequisite to Zonemaster::LDNS.

## Context

See https://github.com/zonemaster/zonemaster-ldns/pull/210.

## Changes

Add `ExtUtils::PkgConfig` to the list of packages to install for all supported operating systems.

## How to test this PR

N/A.
