### PR TITLE
DS03_ILLEGAL_ITERATION_VALUE should be WARNING and not ERROR (DNSSEC03)

### DIFF
--- a/docs/public/specifications/tests/DNSSEC-TP/dnssec03.md
+++ b/docs/public/specifications/tests/DNSSEC-TP/dnssec03.md
@@ -81,7 +81,7 @@ Message Tag outputted              | Level   |Arguments| Message ID for message 
 DS03_ERROR_RESPONSE_NSEC_QUERY     | ERROR   | ns_list | The following servers give erroneous response to NSEC query. Fetched from name servers "{ns_list}".
 DS03_ERR_MULT_NSEC3                | ERROR   | ns_list | Multiple NSEC3 records when one is expected. Fetched from name servers "{ns_list}".
 DS03_ILLEGAL_HASH_ALGO             | ERROR   | ns_list, algo_num | The following servers respond with an illegal hash algorithm for NSEC3 ({algo_num}). Fetched from name servers "{ns_list}".
-DS03_ILLEGAL_ITERATION_VALUE       | ERROR   | ns_list, int | The following servers respond with the NSEC3 iteration value {int}. The recommended practice is to set this value to 0. Fetched from name servers "{ns_list}".
+DS03_ILLEGAL_ITERATION_VALUE       | WARNING | ns_list, int | The following servers respond with the NSEC3 iteration value {int}. The recommended practice is to set this value to 0. Fetched from name servers "{ns_list}".
 DS03_ILLEGAL_SALT_LENGTH           | WARNING | ns_list, int | The following servers respond with a non-empty salt in NSEC3 ({int} octets). The recommended practice is to use an empty salt. Fetched from name servers "{ns_list}".
 DS03_INCONSISTENT_HASH_ALGO        | ERROR   |         | Inconsistent hash algorithm in NSEC3 in responses for the child zone from different name servers.
 DS03_INCONSISTENT_ITERATION        | ERROR   |         | Inconsistent NSEC3 iteration value in responses for the child zone from different name servers.


### PR DESCRIPTION
## Purpose

Even though RFC 9276 says "Validating resolvers MAY also return a SERVFAIL response when processing NSEC3 records with iterations larger than 0", we are not aware about any resolver that would be so strict at the moment. For now and apparently for not short time in the future non zero iterations will not cause immediate operational problem. Reporting non zero iterations as ERROR in DNS zone administration is too strict in this situation.

## Context

https://datatracker.ietf.org/doc/html/rfc9276#name-recommendation-for-validati
