### PR TITLE
Add test zones for Address03

### DIFF
--- a/docs/public/SUMMARY.md
+++ b/docs/public/SUMMARY.md
@@ -40,6 +40,8 @@
     - [Test Types](specifications/test-types/README.md)
         - [Undelegated Test](specifications/test-types/undelegated-test.md)
     - [Test Zones](specifications/test-zones/README.md)
+        - [Address-TP](specifications/test-zones/Address-TP/README.md)
+          - [Address03](specifications/test-zones/Address-TP/address03.md)
         - [Basic-TP](specifications/test-zones/Basic-TP/README.md)
           - [BASIC01](specifications/test-zones/Basic-TP/basic01.md)
         - [Consistency-TP](specifications/test-zones/Consistency-TP/README.md)

--- a/docs/public/specifications/test-zones/Address-TP/README.md
+++ b/docs/public/specifications/test-zones/Address-TP/README.md
@@ -1,0 +1,8 @@
+# Specification of test scenarios for Address-TP
+
+
+Test scenario specifications are available for:
+
+* Address01 *not yet available*
+* Address02 *not yet available*
+* [Address03](address03.md)

--- a/docs/public/specifications/test-zones/Address-TP/address03.md
+++ b/docs/public/specifications/test-zones/Address-TP/address03.md
@@ -1,0 +1,250 @@
+# Specification of Test Scenarios for Address03
+
+
+## Table of contents
+
+
+* [Background](#background)
+* [Test Case](#test-case)
+* [Test scenarios](#test-scenarios)
+* [Test zone names](#test-zone-names)
+* [All message tags](#all-message-tags)
+* [Test scenarios and message tags](#test-scenarios-and-message-tags)
+* [Zone setup for test scenarios]
+
+
+## Background
+
+See the [test scenario README file].
+
+
+## Test Case
+
+This document specifies defined test scenarios for test case [Address03].
+
+
+## Test scenarios
+
+The purpose of the test scenarios is to cover all reasonable contexts where
+different message tags are outputted when [Address03] is run on a test zone.
+The message tags are defined in the test case ([Address03]) and the scenarios
+are defined below.
+
+The test scenarios are structured as stated in the [test scenario README file].
+
+## Test zone names
+
+The test zone for each test scenario in this document is a subdomain delegated
+from the base name (`address03.xa`) and that subdomain having the same name as
+the scenario. The names of those zones are given in section "[Test scenarios
+and setup of test zones]" below.
+
+## All message tags
+
+The test case can output any of these message tags, but not necessarily in any
+combination. See [Address03] for the specification of the tags.
+
+* NAMESERVER_IP_PTR_MATCH
+* NAMESERVER_IP_PTR_MISMATCH
+* NAMESERVER_IP_WITHOUT_REVERSE
+* NO_RESPONSE_PTR_QUERY
+
+
+## Test scenarios and message tags
+
+If a message tag is not listed for the scenario, its presence or non-presence is
+irrelevant to the test scenario and must be ignored.
+
+| Scenario name              | Mandatory message tags        | Forbidden message tags                              |
+|:---------------------------|:------------------------------|:----------------------------------------------------|
+| ALL-NS-HAVE-PTR-1          | NAMESERVER_IP_PTR_MATCH       | 2)                                                  |
+| ALL-NS-HAVE-PTR-2          | NAMESERVER_IP_PTR_MATCH       | 2)                                                  |
+| NO-NS-HAVE-PTR             | NAMESERVER_IP_WITHOUT_REVERSE | 2)                                                  |
+| INCOMPLETE-PTR-1           | NAMESERVER_IP_WITHOUT_REVERSE | 2)                                                  |
+| INCOMPLETE-PTR-2           | NAMESERVER_IP_WITHOUT_REVERSE | 2)                                                  |
+| NON-MATCHING-NAMES         | NAMESERVER_IP_PTR_MISMATCH    | 2)                                                  |
+| PTR-IS-GOOD-CNAME-1        | NAMESERVER_IP_PTR_MATCH       | 2)                                                  |
+| PTR-IS-GOOD-CNAME-2        | NAMESERVER_IP_PTR_MATCH       | 2)                                                  |
+| PTR-IS-DANGLING-CNAME      | NAMESERVER_IP_WITHOUT_REVERSE | 2)                                                  |
+| PTR-IS-ILLEGAL-CNAME       | NAMESERVER_IP_WITHOUT_REVERSE | NAMESERVER_IP_PTR_MATCH, NAMESERVER_IP_PTR_MISMATCH |
+| PTR-RESOLUTION-NO-RESPONSE | NO_RESPONSE_PTR_QUERY         | NAMESERVER_IP_PTR_MATCH, NAMESERVER_IP_PTR_MISMATCH |
+| PTR-RESOLUTION-SERVFAIL    | NO_RESPONSE_PTR_QUERY         | NAMESERVER_IP_PTR_MATCH, NAMESERVER_IP_PTR_MISMATCH |
+
+* (1) All tags except for those specified as "Forbidden message tags" (no instances for these test scenarios)
+* (2) All tags except for those specified as "Mandatory message tags"
+
+
+## Test scenarios and setup of test zones
+
+### Default zone configuration
+Unless otherwise specified in the specific scenario specification, the test zone
+for the scenario will follow the default setup as stated below. The `child zone`
+is the zone to be tested for the scenario.
+
+* The child zone is `SCENARIO.address03.xa`.
+  * There is a zone file for the child zone.
+  * The child zone is delegated to two out-of-bailiwick name servers.
+  * Both name servers have the same content.
+  * The authoritative name servers for the zone all have an IPv4 and an IPv6
+    address, and the reverse zones contain a single PTR resource record
+    matching their names for all of their addresses.
+  * The NS record set in the child zone is consistent with the parent zone’s
+    delegation.
+* The parent zone is `address03.xa`.
+  * It is served by two in-bailiwick NS (ns1.address03.xa and
+    ns2.address03.xa).
+  * ns1 and ns2 have the same zone content.
+  * ns1 and ns2 have both IPv4 and IPv6 glue in the delegation of the parent
+    zone.
+  * The records matching glue in the zone are identical to the glue records.
+* All authoritative name servers for the scenario’s child zones have names
+  matching ns\<NUMBER\>.child.address03.xa. These name servers’s names are
+  abbreviated by leaving out address03.xa from their names.
+* All responses will have the AA bit set.
+* All responses will have the [RCODE Name] "NoError".
+
+### ALL-NS-HAVE-PTR-1
+
+A happy path: a zone whose name server IP addresses have single and correct
+PTR records.
+
+* Zone: all-ns-have-ptr-1.address03.xa
+  * Delegated to: ns1.child and ns2.child.
+
+### ALL-NS-HAVE-PTR-2
+
+Another happy path: like ALL-NS-HAVE-PTR-1, but for one of the name servers,
+both its IPv4 and IPv6 addresses have multiple PTR records. In each PTR
+resource record set, one of the PTR records matches the name server’s name.
+
+* Zone: all-ns-have-ptr-2.address03.xa
+  * Delegated to: ns1.child and ns3.child.
+  * ns3.child’s IP addresses have multiple PTR records, among which one points
+    to ns3.child.
+
+### NO-NS-HAVE-PTR
+
+None of the name server’s IP addresses have PTR records at all. For one of
+them, NODATA is returned on PTR query; for the other, NXDOMAIN is returned.
+
+* Zone: no-ns-have-ptr.address03.xa
+  * Delegated to: ns4.child and ns5.child.
+  * ns4.child’s IP addresses have no PTR records; the reverse zone is
+    configured to provoke NODATA responses on PTR queries by making the
+    expected node an empty non-terminal.
+  * ns5.child’s IP addresses have no PTR records; the reverse zone is
+    configured to provoke NXDOMAIN responses on PTR queries.
+
+### INCOMPLETE-PTR-1
+
+For one of the name servers, the PTR record is missing for its IPv4 address.
+
+* Zone: incomplete-ptr-1.address03.xa
+  * Delegated to: ns1.child and ns6.child.
+  * ns6.child’s IPv4 address has no PTR record, but its IPv6 address does.
+
+### INCOMPLETE-PTR-2
+
+For one of the name servers, the PTR record is missing for its IPv6 address.
+
+* Zone: incomplete-ptr-2.address03.xa
+  * Delegated to: ns1.child and ns7.child.
+  * ns7.child’s IPv4 address has a PTR record, but its IPv6 address does not.
+
+### NON-MATCHING-NAMES
+
+Both name server’s IP addresses have one or more PTR records, but none
+matching the name server name.
+
+* Zone: non-matching-names.address03.xa
+  * Delegated to: ns8.child and ns9.child.
+  * ns8.child’s IP addresses have a single PTR record, but its hostname in
+    RDATA is different from the name server’s name.
+  * ns9.child’s IP addresses have more than one PTR record, and each of them
+    has a hostname in RDATA different from the name server’s name.
+
+### PTR-IS-GOOD-CNAME-1
+
+The reverse name of one of the name servers’ IP address has an alias (CNAME)
+whose target, with a PTR record, is in the same reverse zone.
+
+* Zone: ptr-is-good-cname-1.address03.xa
+  * Delegated to: ns1.child and ns10.child.
+  * ns10.child’s IP addresses have reverse names that are aliased (CNAME) to
+    another name in the same zone. In other words, resolving the PTR resource
+    records for their IP addresses returns a CNAME resource record and the PTR
+    record after walking the CNAME chain.
+
+### PTR-IS-GOOD-CNAME-2
+
+The reverse name of one of the name servers’ IP address has an alias (CNAME)
+whose target, with a PTR record, is in a different zone.
+
+* Zone: ptr-is-good-cname-2.address03.xa
+  * Delegated to: ns1.child and ns11.child.
+  * ns11.child’s IP addresses have reverse names that are aliased (CNAME) to
+    another name in a different zone. In other words, resolving the PTR
+    resource records for their IP addresses returns only a CNAME resource
+    record, and another query for the name at the target of the CNAME resource
+    record is needed.
+
+### PTR-IS-DANGLING-CNAME
+
+The reverse name of one of the name servers’ IP address has an alias (CNAME)
+whose target does not exist.
+
+* Zone: ptr-is-dangling-cname.address03.xa
+  * Delegated to: ns5.child and ns12.child.
+  * ns5.child is configured as described in the NO-NS-HAVE-PTR scenario.
+  * ns12.child’s IP addresses have reverse names that are aliased to a
+    nonexistent node. In other words, there is a CNAME pointing to a node
+    that does not exist.
+
+### PTR-IS-ILLEGAL-CNAME
+
+One of the name servers has IP addresses whose reverse names contain more than
+one CNAME resource record.
+
+* Zone: ptr-is-illegal-cname.address03.xa
+  * Delegated to: ns4.child and ns13.child.
+  * ns4.child is configured as described in the NO-NS-HAVE-PTR scenario.
+  * ns13.child’s IP addresses have reverse names that give two CNAME
+    resource records.
+    
+Whether or not NO_RESPONSE_PTR_QUERY is allowed to be outputted is
+intentionally left unspecified.
+    
+### PTR-RESOLUTION-NO-RESPONSE
+
+One of the name servers has IP addresses whose reverse names fail to resolve
+because the authoritative name server for the reverse zone does not respond.
+
+One of the name servers’ IP addresses fail to resolve to PTR records because
+an attempt at querying corresponding node in the `in-addr.arpa` or `ip6.arpa`
+subtrees returns no response.
+
+* Zone: ptr-resolution-no-response.address03.xa
+  * Delegated to: ns1.child and ns14.child.
+  * Querying the PTR records for ns14.child’s IP addresses return no response.
+  
+Whether or not NAMESERVER_IP_WITHOUT_REVERSE is allowed to be outputted is
+intentionally left unspecified.
+
+### PTR-RESOLUTION-SERVFAIL
+
+One of the name servers has IP addresses whose reverse names fail to resolve
+because the authoritative name server for the reverse zone gives a response
+whose [RCODE Name] is neither "NoError" nor "NXDomain".
+
+* Zone: ptr-resolution-no-response.address03.xa
+  * Delegated to: ns1.child and ns15.child.
+  * Querying the PTR records for ns15.child’s IP addresses return a "ServFail"
+    response.
+
+Whether or not NAMESERVER_IP_WITHOUT_REVERSE is allowed to be outputted is
+intentionally left unspecified.
+
+[ADDRESS03]:                     ../../tests/Address-TP/address03.md
+[RCODE Name]:                    https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-6
+[test scenario README file]:     ../README.md
+[Zone setup for test scenarios]: #zone-setup-for-test-scenarios

--- a/test-zone-data/Address-TP/address03/3.0.0.0.1.1.0.0.7.2.1.0.0.0.0.0.3.c.0.0.2.b.0.0.1.a.d.f.ip6.arpa.zone
+++ b/test-zone-data/Address-TP/address03/3.0.0.0.1.1.0.0.7.2.1.0.0.0.0.0.3.c.0.0.2.b.0.0.1.a.d.f.ip6.arpa.zone
@@ -1,0 +1,83 @@
+$ORIGIN 3.0.0.0.1.1.0.0.7.2.1.0.0.0.0.0.3.c.0.0.2.b.0.0.1.a.d.f.ip6.arpa. ; Must end with "."
+$TTL 3600
+
+@       SOA     ns1 admin. (
+                2025022400      ; serial
+                6h              ; refresh
+                1h              ; retry
+                1w              ; expire
+                1d )            ; minimum
+
+                NS	ns1.address03.xa.
+                NS	ns2.address03.xa.
+;;;
+;;; Name servers for parent zone
+;;;
+1.2.0.0         PTR     ns1.address03.xa.
+2.2.0.0         PTR     ns2.address03.xa.
+
+;;;
+;;; Name servers for child (scenario) zones
+;;;
+
+;; For the “happy path”.
+1.3.0.0         PTR     ns1.child.address03.xa.
+
+;; One more for the “happy path”.
+2.3.0.0         PTR     ns2.child.address03.xa.
+
+;; Multiple PTR records, among which one matches the actual name server name.
+;; For the curious: the languages used are English, French, Swedish, German,
+;; Dutch and Esperanto.
+3.3.0.0         PTR     ns3.child.address03.xa.
+                PTR     name-server-three.child.address03.xa.
+                PTR     serveur-de-noms-trois.child.address03.xa.
+                PTR     namnsevrar-tre.child.address03.xa.
+                PTR     nameserver-drei.child.address03.xa.
+                PTR     naamserver-drie.child.address03.xa.
+                PTR     nomservilo-tri.child.address03.xa.
+
+;; Empty non-terminal.
+_.4.3.0.0       TXT     "To make the parent node an empty non-terminal"
+
+
+;; Nonexistent node. This name server has no reverse DNS at all.
+; 5.3.0.0       PTR     nothing-here.invalid.
+
+;; This name server has reverse DNS for IPv6 only, none for IPv4.
+6.3.0.0         PTR     ns6.child.address03.xa.
+
+;; Nonexistent node. This name server has reverse DNS for IPv4 only, none for IPv6.
+; 7.3.0.0       PTR     ns7.child.address03.xa.
+
+;; Non-matching name.
+8.3.0.0         PTR     a-naughty-nameserver.child.address03.xa.
+
+;; Multiple non-matching names.
+9.3.0.0         PTR     non-matching-set-1.child.address03.xa.
+                PTR     non-matching-set-2.child.address03.xa.
+
+;; An alias to a node with a good PTR record set (which is legal, and can
+;; happen with classless IN-ADDR.ARPA delegation, as in RFC 2317).
+0.4.0.0         CNAME   0-4-0-0.alias
+0-4-0-0.alias   PTR     ns10.child.address03.xa.
+
+;; Another good alias, but the target is in another zone.
+1.4.0.0         CNAME   1-4-0-0.reverse-aliases.address03.xa.
+
+;; A dangling alias (pointing to a nonexistent node).
+2.4.0.0         CNAME   dangling.alias
+
+;; An illegal alias (with more than one CNAME RR).
+;; NOTE: The resolver MUST NOT attempt to follow any of the CNAME resource records!
+3.4.0.0         CNAME   illegal1.alias
+                CNAME   illegal2.alias
+
+;; Queries for the following name must be dropped.
+; 4.4.0.0         PTR     ns14.child.address03.xa.
+
+;; Queries for the following name must fail with RCODE SERVFAIL.
+; 5.4.0.0         PTR     ns15.child.address03.xa.
+
+illegal1.alias  PTR     ns13.child.address03.xa.
+illegal2.alias  PTR     ns13.child.address03.xa.

--- a/test-zone-data/Address-TP/address03/3.11.127.in-addr.arpa.zone
+++ b/test-zone-data/Address-TP/address03/3.11.127.in-addr.arpa.zone
@@ -1,0 +1,83 @@
+$ORIGIN 3.11.127.in-addr.arpa. ; Must end with "."
+$TTL 3600
+
+@       SOA     ns1 admin. (
+                2025022400      ; serial
+                6h              ; refresh
+                1h              ; retry
+                1w              ; expire
+                1d )            ; minimum
+
+                NS	ns1.address03.xa.
+                NS	ns2.address03.xa.
+;;;
+;;; Name servers for parent zone
+;;;
+21              PTR     ns1.address03.xa.
+22              PTR     ns2.address03.xa.
+
+;;;
+;;; Name servers for child (scenario) zones
+;;;
+
+;; For the “happy path”.
+31              PTR     ns1.child.address03.xa.
+
+;; One more for the “happy path”.
+32              PTR     ns2.child.address03.xa.
+
+;; Multiple PTR records, among which one matches the actual name server name.
+;; For the curious: the languages used are English, French, Swedish, German,
+;; Dutch and Esperanto.
+33              PTR     ns3.child.address03.xa.
+                PTR     name-server-three.child.address03.xa.
+                PTR     serveur-de-noms-trois.child.address03.xa.
+                PTR     namnsevrar-tre.child.address03.xa.
+                PTR     nameserver-drei.child.address03.xa.
+                PTR     naamserver-drie.child.address03.xa.
+                PTR     nomservilo-tri.child.address03.xa.
+
+;; Empty non-terminal.
+_.34            TXT     "To make the parent node an empty non-terminal"
+
+
+;; Nonexistent node. This name server has no reverse DNS at all.
+; 35            PTR     nothing-here.invalid.
+
+;; Nonexistent node. This name server has reverse DNS for IPv6 only, none for IPv4.
+; 36            PTR     ns6.child.address03.xa.
+
+;; This name server has reverse DNS for IPv4 only, none for IPv6.
+37              PTR     ns7.child.address03.xa.
+
+;; Non-matching name.
+38              PTR     a-naughty-nameserver.child.address03.xa.
+
+;; Multiple non-matching names.
+39              PTR     non-matching-set-1.child.address03.xa.
+                PTR     non-matching-set-2.child.address03.xa.
+
+;; An alias to a node with a good PTR record set (which is legal, and can
+;; happen with classless IN-ADDR.ARPA delegation, as in RFC 2317).
+40              CNAME   40.alias
+40.alias        PTR     ns10.child.address03.xa.
+
+;; Another good alias, but the target is another zone.
+41              CNAME   41.reverse-aliases.address03.xa.
+
+;; A dangling alias (pointing to a nonexistent node).
+42              CNAME   dangling.alias
+
+;; An illegal alias (with more than one CNAME RR).
+;; NOTE: The resolver MUST NOT attempt to follow any of the CNAME resource records!
+43              CNAME   illegal1.alias
+                CNAME   illegal2.alias
+
+;; Queries for the following name must be dropped.
+; 44              PTR     ns14.child.address03.xa.
+
+;; Queries for the following name must fail with RCODE SERVFAIL.
+; 45              PTR     ns15.child.address03.xa.
+
+illegal1.alias  PTR     ns13.child.address03.xa.
+illegal2.alias  PTR     ns13.child.address03.xa.

--- a/test-zone-data/Address-TP/address03/README.md
+++ b/test-zone-data/Address-TP/address03/README.md
@@ -1,0 +1,13 @@
+[This directory], i.e. the same directory as this README file, holds zone
+files and configuration files to implement the test zones for the scenarios
+defined in [Address03 test scenario specification].
+
+For these test zones the following files are found in [this directory]:
+* Zone files for `address03.xa` and other related zones;
+* CoreDNS configuration file;
+* Output from `zonemaster-cli` on all test scenarios in
+  [Address03 Test Zones Output].
+
+[Address03 Test Zones Output]:                ./test-zones-output.md
+[Address03 test scenario specification]:      ../../../docs/public/specifications/test-zones/Address-TP/address03.md
+[This directory]:                             .

--- a/test-zone-data/Address-TP/address03/address03.cfg
+++ b/test-zone-data/Address-TP/address03/address03.cfg
@@ -1,0 +1,185 @@
+# address03.xa
+address03.xa:53 {
+    bind 127.11.3.21                # ns1
+    bind fda1:b2:c3::127:11:3:21    # ns1
+    bind 127.11.3.22                # ns2
+    bind fda1:b2:c3::127:11:3:22    # ns2
+    log
+    file Address-TP/address03/address03.xa.zone address03.xa
+}
+
+# reverse-aliases.address03.xa
+reverse-aliases.address03.xa:53 {
+    bind 127.11.3.31                # ns1.child
+    bind fda1:b2:c3::127:11:3:31    # ns1.child
+    bind 127.11.3.32                # ns2.child
+    bind fda1:b2:c3::127:11:3:32    # ns2.child
+    log
+    file Address-TP/address03/reverse-aliases.address03.xa.zone reverse-aliases.address03.xa
+}
+
+# 3.11.127.in-addr.arpa
+3.11.127.in-addr.arpa:53 {
+    bind 127.11.3.21                # ns1
+    bind fda1:b2:c3::127:11:3:21    # ns1
+    bind 127.11.3.22                # ns2
+    bind fda1:b2:c3::127:11:3:22    # ns2
+    log
+    file Address-TP/address03/3.11.127.in-addr.arpa.zone 3.11.127.in-addr.arpa
+
+    acl 44.3.11.127.in-addr.arpa {
+        drop
+    }
+    template IN ANY 45.3.11.127.in-addr.arpa {
+        rcode SERVFAIL
+    }
+}
+
+# 3.0.0.0.1.1.0.0.7.2.1.0.0.0.0.0.3.c.0.0.2.b.0.0.1.a.d.f.ip6.arpa
+3.0.0.0.1.1.0.0.7.2.1.0.0.0.0.0.3.c.0.0.2.b.0.0.1.a.d.f.ip6.arpa:53 {
+    bind 127.11.3.21                # ns1
+    bind fda1:b2:c3::127:11:3:21    # ns1
+    bind 127.11.3.22                # ns2
+    bind fda1:b2:c3::127:11:3:22    # ns2
+    log
+    file Address-TP/address03/3.0.0.0.1.1.0.0.7.2.1.0.0.0.0.0.3.c.0.0.2.b.0.0.1.a.d.f.ip6.arpa.zone 3.0.0.0.1.1.0.0.7.2.1.0.0.0.0.0.3.c.0.0.2.b.0.0.1.a.d.f.ip6.arpa
+
+    acl 4.4.0.0.3.0.0.0.1.1.0.0.7.2.1.0.0.0.0.0.3.c.0.0.2.b.0.0.1.a.d.f.ip6.arpa {
+        drop
+    }
+    template IN ANY 5.4.0.0.3.0.0.0.1.1.0.0.7.2.1.0.0.0.0.0.3.c.0.0.2.b.0.0.1.a.d.f.ip6.arpa {
+        rcode SERVFAIL
+    }
+}
+
+### ALL-NS-HAVE-PTR-1
+# all-ns-have-ptr-1.address03.xa.
+all-ns-have-ptr-1.address03.xa:53 {
+    bind 127.11.3.31                # ns1.child
+    bind fda1:b2:c3::127:11:3:31    # ns1.child
+    bind 127.11.3.32                # ns2.child
+    bind fda1:b2:c3::127:11:3:32    # ns2.child
+    log
+    file Address-TP/address03/all-ns-have-ptr-1.address03.xa.zone all-ns-have-ptr-1.address03.xa
+}
+
+### ALL-NS-HAVE-PTR-2
+# all-ns-have-ptr-2.address03.xa.
+all-ns-have-ptr-2.address03.xa:53 {
+    bind 127.11.3.31                # ns1.child
+    bind fda1:b2:c3::127:11:3:31    # ns1.child
+    bind 127.11.3.33                # ns3.child
+    bind fda1:b2:c3::127:11:3:33    # ns3.child
+    log
+    file Address-TP/address03/all-ns-have-ptr-2.address03.xa.zone all-ns-have-ptr-2.address03.xa
+}
+
+### NO-NS-HAVE-PTR
+# no-ns-have-ptr.address03.xa.
+no-ns-have-ptr.address03.xa:53 {
+    bind 127.11.3.34                # ns4.child
+    bind fda1:b2:c3::127:11:3:34    # ns4.child
+    bind 127.11.3.35                # ns5.child
+    bind fda1:b2:c3::127:11:3:35    # ns5.child
+    log
+    file Address-TP/address03/no-ns-have-ptr.address03.xa.zone no-ns-have-ptr.address03.xa
+}
+
+### INCOMPLETE-PTR-1
+# incomplete-ptr-1.address03.xa.
+incomplete-ptr-1.address03.xa:53 {
+    bind 127.11.3.31                # ns1.child
+    bind fda1:b2:c3::127:11:3:31    # ns1.child
+    bind 127.11.3.36                # ns6.child
+    bind fda1:b2:c3::127:11:3:36    # ns6.child
+    log
+    file Address-TP/address03/incomplete-ptr-1.address03.xa.zone incomplete-ptr-1.address03.xa
+}
+
+### INCOMPLETE-PTR-2
+# incomplete-ptr-2.address03.xa.
+incomplete-ptr-2.address03.xa:53 {
+    bind 127.11.3.31                # ns1.child
+    bind fda1:b2:c3::127:11:3:31    # ns1.child
+    bind 127.11.3.37                # ns7.child
+    bind fda1:b2:c3::127:11:3:37    # ns7.child
+    log
+    file Address-TP/address03/incomplete-ptr-2.address03.xa.zone incomplete-ptr-2.address03.xa
+}
+
+### NON-MATCHING-NAMES
+# non-matching-names.address03.xa.
+non-matching-names.address03.xa:53 {
+    bind 127.11.3.38                # ns8.child
+    bind fda1:b2:c3::127:11:3:38    # ns8.child
+    bind 127.11.3.39                # ns9.child
+    bind fda1:b2:c3::127:11:3:39    # ns9.child
+    log
+    file Address-TP/address03/non-matching-names.address03.xa.zone non-matching-names.address03.xa
+}
+
+### PTR-IS-GOOD-CNAME-1
+# ptr-is-good-cname-1.address03.xa.
+ptr-is-good-cname-1.address03.xa:53 {
+    bind 127.11.3.31                # ns1.child
+    bind fda1:b2:c3::127:11:3:31    # ns1.child
+    bind 127.11.3.40                # ns10.child
+    bind fda1:b2:c3::127:11:3:40    # ns10.child
+    log
+    file Address-TP/address03/ptr-is-good-cname-1.address03.xa.zone ptr-is-good-cname-1.address03.xa
+}
+
+### PTR-IS-GOOD-CNAME-2
+# ptr-is-good-cname-2.address03.xa.
+ptr-is-good-cname-2.address03.xa:53 {
+    bind 127.11.3.31                # ns1.child
+    bind fda1:b2:c3::127:11:3:31    # ns1.child
+    bind 127.11.3.41                # ns11.child
+    bind fda1:b2:c3::127:11:3:41    # ns11.child
+    log
+    file Address-TP/address03/ptr-is-good-cname-2.address03.xa.zone ptr-is-good-cname-2.address03.xa
+}
+
+### PTR-IS-DANGLING-CNAME
+# ptr-is-dangling-cname.address03.xa.
+ptr-is-dangling-cname.address03.xa:53 {
+    bind 127.11.3.35                # ns5.child
+    bind fda1:b2:c3::127:11:3:35    # ns5.child
+    bind 127.11.3.42                # ns12.child
+    bind fda1:b2:c3::127:11:3:42    # ns12.child
+    log
+    file Address-TP/address03/ptr-is-dangling-cname.address03.xa.zone ptr-is-dangling-cname.address03.xa
+}
+
+### PTR-IS-ILLEGAL-CNAME
+# ptr-is-illegal-cname.address03.xa.
+ptr-is-illegal-cname.address03.xa:53 {
+    bind 127.11.3.34                # ns4.child
+    bind fda1:b2:c3::127:11:3:34    # ns4.child
+    bind 127.11.3.43                # ns13.child
+    bind fda1:b2:c3::127:11:3:43    # ns13.child
+    log
+    file Address-TP/address03/ptr-is-illegal-cname.address03.xa.zone ptr-is-illegal-cname.address03.xa
+}
+
+### PTR-RESOLUTION-NO-RESPONSE
+# ptr-resolution-no-response.address03.xa.
+ptr-resolution-no-response.address03.xa:53 {
+    bind 127.11.3.31                # ns1.child
+    bind fda1:b2:c3::127:11:3:31    # ns1.child
+    bind 127.11.3.44                # ns14.child
+    bind fda1:b2:c3::127:11:3:44    # ns14.child
+    log
+    file Address-TP/address03/ptr-resolution-no-response.address03.xa.zone ptr-resolution-no-response.address03.xa
+}
+
+### PTR-RESOLUTION-SERVFAIL
+# ptr-resolution-servfail.address03.xa.
+ptr-resolution-servfail.address03.xa:53 {
+    bind 127.11.3.31                # ns1.child
+    bind fda1:b2:c3::127:11:3:31    # ns1.child
+    bind 127.11.3.45                # ns15.child
+    bind fda1:b2:c3::127:11:3:45    # ns15.child
+    log
+    file Address-TP/address03/ptr-resolution-servfail.address03.xa.zone ptr-resolution-servfail.address03.xa
+}

--- a/test-zone-data/Address-TP/address03/address03.xa.zone
+++ b/test-zone-data/Address-TP/address03/address03.xa.zone
@@ -1,0 +1,99 @@
+$ORIGIN address03.xa.                            ; Must end with "."
+$TTL 3600
+
+@       SOA     ns1 admin. (
+                2025022400      ; serial
+                6h              ; refresh
+                1h              ; retry
+                1w              ; expire
+                1d )            ; minimum
+
+                        NS	ns1
+                        NS	ns2
+
+ns1		        A	127.11.3.21
+ns1		        AAAA	fda1:b2:c3::127:11:3:21
+ns2		        A	127.11.3.22
+ns2		        AAAA	fda1:b2:c3::127:11:3:22
+
+;;;
+;;; Name servers for child (scenario) zones
+;;;
+
+ns1.child               A       127.11.3.31
+ns1.child               AAAA    fda1:b2:c3::127:11:3:31
+ns2.child               A       127.11.3.32
+ns2.child               AAAA    fda1:b2:c3::127:11:3:32
+ns3.child               A       127.11.3.33
+ns3.child               AAAA    fda1:b2:c3::127:11:3:33
+ns4.child               A       127.11.3.34
+ns4.child               AAAA    fda1:b2:c3::127:11:3:34
+ns5.child               A       127.11.3.35
+ns5.child               AAAA    fda1:b2:c3::127:11:3:35
+ns6.child               A       127.11.3.36
+ns6.child               AAAA    fda1:b2:c3::127:11:3:36
+ns7.child               A       127.11.3.37
+ns7.child               AAAA    fda1:b2:c3::127:11:3:37
+ns8.child               A       127.11.3.38
+ns8.child               AAAA    fda1:b2:c3::127:11:3:38
+ns9.child               A       127.11.3.39
+ns9.child               AAAA    fda1:b2:c3::127:11:3:39
+ns10.child              A       127.11.3.40
+ns10.child              AAAA    fda1:b2:c3::127:11:3:40
+ns11.child              A       127.11.3.41
+ns11.child              AAAA    fda1:b2:c3::127:11:3:41
+ns12.child              A       127.11.3.42
+ns12.child              AAAA    fda1:b2:c3::127:11:3:42
+ns13.child              A       127.11.3.43
+ns13.child              AAAA    fda1:b2:c3::127:11:3:43
+ns14.child              A       127.11.3.44
+ns14.child              AAAA    fda1:b2:c3::127:11:3:44
+ns15.child              A       127.11.3.45
+ns15.child              AAAA    fda1:b2:c3::127:11:3:45
+
+;;;
+;;; Some targets of aliases (CNAMEs) need to be in another zone
+;;;
+
+reverse-aliases         NS      ns1.child
+reverse-aliases         NS      ns2.child
+
+;;;
+;;; Scenario definitions
+;;;
+
+all-ns-have-ptr-1           NS  ns1.child
+all-ns-have-ptr-1           NS  ns2.child
+
+all-ns-have-ptr-2           NS  ns1.child
+all-ns-have-ptr-2           NS  ns3.child
+
+no-ns-have-ptr              NS  ns4.child
+no-ns-have-ptr              NS  ns5.child
+
+incomplete-ptr-1            NS  ns1.child
+incomplete-ptr-1            NS  ns6.child
+
+incomplete-ptr-2            NS  ns1.child
+incomplete-ptr-2            NS  ns7.child
+
+non-matching-names          NS  ns8.child
+non-matching-names          NS  ns9.child
+
+ptr-is-good-cname-1         NS  ns1.child
+ptr-is-good-cname-1         NS  ns10.child
+
+ptr-is-good-cname-2         NS  ns1.child
+ptr-is-good-cname-2         NS  ns11.child
+
+ptr-is-dangling-cname       NS  ns5.child
+ptr-is-dangling-cname       NS  ns12.child
+
+ptr-is-illegal-cname        NS  ns4.child
+ptr-is-illegal-cname        NS  ns13.child
+
+ptr-resolution-no-response  NS  ns1.child
+ptr-resolution-no-response  NS  ns14.child
+
+ptr-resolution-servfail     NS  ns1.child
+ptr-resolution-servfail     NS  ns15.child

--- a/test-zone-data/Address-TP/address03/all-ns-have-ptr-1.address03.xa.zone
+++ b/test-zone-data/Address-TP/address03/all-ns-have-ptr-1.address03.xa.zone
@@ -1,0 +1,12 @@
+$ORIGIN all-ns-have-ptr-1.address03.xa. ; Must end with "."
+$TTL 3600
+
+@       SOA     ns1.child.address03.xa. admin. (
+                2025022400      ; serial
+                6h              ; refresh
+                1h              ; retry
+                1w              ; expire
+                1d )            ; minimum
+
+                NS	ns1.child.address03.xa.
+                NS	ns2.child.address03.xa.

--- a/test-zone-data/Address-TP/address03/all-ns-have-ptr-2.address03.xa.zone
+++ b/test-zone-data/Address-TP/address03/all-ns-have-ptr-2.address03.xa.zone
@@ -1,0 +1,12 @@
+$ORIGIN all-ns-have-ptr-2.address03.xa. ; Must end with "."
+$TTL 3600
+
+@       SOA     ns1.child.address03.xa. admin. (
+                2025022400      ; serial
+                6h              ; refresh
+                1h              ; retry
+                1w              ; expire
+                1d )            ; minimum
+
+                NS	ns1.child.address03.xa.
+                NS	ns3.child.address03.xa.

--- a/test-zone-data/Address-TP/address03/incomplete-ptr-1.address03.xa.zone
+++ b/test-zone-data/Address-TP/address03/incomplete-ptr-1.address03.xa.zone
@@ -1,0 +1,12 @@
+$ORIGIN incomplete-ptr-1.address03.xa. ; Must end with "."
+$TTL 3600
+
+@       SOA     ns1.child.address03.xa. admin. (
+                2025022400      ; serial
+                6h              ; refresh
+                1h              ; retry
+                1w              ; expire
+                1d )            ; minimum
+
+                NS	ns1.child.address03.xa.
+                NS	ns6.child.address03.xa.

--- a/test-zone-data/Address-TP/address03/incomplete-ptr-2.address03.xa.zone
+++ b/test-zone-data/Address-TP/address03/incomplete-ptr-2.address03.xa.zone
@@ -1,0 +1,12 @@
+$ORIGIN incomplete-ptr-2.address03.xa. ; Must end with "."
+$TTL 3600
+
+@       SOA     ns1.child.address03.xa. admin. (
+                2025022400      ; serial
+                6h              ; refresh
+                1h              ; retry
+                1w              ; expire
+                1d )            ; minimum
+
+                NS	ns1.child.address03.xa.
+                NS	ns7.child.address03.xa.

--- a/test-zone-data/Address-TP/address03/no-ns-have-ptr.address03.xa.zone
+++ b/test-zone-data/Address-TP/address03/no-ns-have-ptr.address03.xa.zone
@@ -1,0 +1,12 @@
+$ORIGIN no-ns-have-ptr.address03.xa. ; Must end with "."
+$TTL 3600
+
+@       SOA     ns4.child.address03.xa. admin. (
+                2025022400      ; serial
+                6h              ; refresh
+                1h              ; retry
+                1w              ; expire
+                1d )            ; minimum
+
+                NS	ns4.child.address03.xa.
+                NS	ns5.child.address03.xa.

--- a/test-zone-data/Address-TP/address03/non-matching-names.address03.xa.zone
+++ b/test-zone-data/Address-TP/address03/non-matching-names.address03.xa.zone
@@ -1,0 +1,12 @@
+$ORIGIN non-matching-names.address03.xa. ; Must end with "."
+$TTL 3600
+
+@       SOA     ns8.child.address03.xa. admin. (
+                2025022400      ; serial
+                6h              ; refresh
+                1h              ; retry
+                1w              ; expire
+                1d )            ; minimum
+
+                NS	ns8.child.address03.xa.
+                NS	ns9.child.address03.xa.

--- a/test-zone-data/Address-TP/address03/ptr-is-dangling-cname.address03.xa.zone
+++ b/test-zone-data/Address-TP/address03/ptr-is-dangling-cname.address03.xa.zone
@@ -1,0 +1,12 @@
+$ORIGIN ptr-is-dangling-cname.address03.xa. ; Must end with "."
+$TTL 3600
+
+@       SOA     ns5.child.address03.xa. admin. (
+                2025022400      ; serial
+                6h              ; refresh
+                1h              ; retry
+                1w              ; expire
+                1d )            ; minimum
+
+                NS	ns5.child.address03.xa.
+                NS	ns12.child.address03.xa.

--- a/test-zone-data/Address-TP/address03/ptr-is-good-cname-1.address03.xa.zone
+++ b/test-zone-data/Address-TP/address03/ptr-is-good-cname-1.address03.xa.zone
@@ -1,0 +1,12 @@
+$ORIGIN ptr-is-good-cname-1.address03.xa. ; Must end with "."
+$TTL 3600
+
+@       SOA     ns1.child.address03.xa. admin. (
+                2025022400      ; serial
+                6h              ; refresh
+                1h              ; retry
+                1w              ; expire
+                1d )            ; minimum
+
+                NS	ns1.child.address03.xa.
+                NS	ns10.child.address03.xa.

--- a/test-zone-data/Address-TP/address03/ptr-is-good-cname-2.address03.xa.zone
+++ b/test-zone-data/Address-TP/address03/ptr-is-good-cname-2.address03.xa.zone
@@ -1,0 +1,12 @@
+$ORIGIN ptr-is-good-cname-2.address03.xa. ; Must end with "."
+$TTL 3600
+
+@       SOA     ns1.child.address03.xa. admin. (
+                2025022400      ; serial
+                6h              ; refresh
+                1h              ; retry
+                1w              ; expire
+                1d )            ; minimum
+
+                NS	ns1.child.address03.xa.
+                NS	ns11.child.address03.xa.

--- a/test-zone-data/Address-TP/address03/ptr-is-illegal-cname.address03.xa.zone
+++ b/test-zone-data/Address-TP/address03/ptr-is-illegal-cname.address03.xa.zone
@@ -1,0 +1,12 @@
+$ORIGIN ptr-is-illegal-cname.address03.xa. ; Must end with "."
+$TTL 3600
+
+@       SOA     ns4.child.address03.xa. admin. (
+                2025022400      ; serial
+                6h              ; refresh
+                1h              ; retry
+                1w              ; expire
+                1d )            ; minimum
+
+                NS	ns4.child.address03.xa.
+                NS	ns13.child.address03.xa.

--- a/test-zone-data/Address-TP/address03/ptr-resolution-no-response.address03.xa.zone
+++ b/test-zone-data/Address-TP/address03/ptr-resolution-no-response.address03.xa.zone
@@ -1,0 +1,12 @@
+$ORIGIN ptr-resolution-no-response.address03.xa. ; Must end with "."
+$TTL 3600
+
+@       SOA     ns1.child.address03.xa. admin. (
+                2025022400      ; serial
+                6h              ; refresh
+                1h              ; retry
+                1w              ; expire
+                1d )            ; minimum
+
+                NS	ns1.child.address03.xa.
+                NS	ns14.child.address03.xa.

--- a/test-zone-data/Address-TP/address03/ptr-resolution-servfail.address03.xa.zone
+++ b/test-zone-data/Address-TP/address03/ptr-resolution-servfail.address03.xa.zone
@@ -1,0 +1,12 @@
+$ORIGIN ptr-resolution-servfail.address03.xa. ; Must end with "."
+$TTL 3600
+
+@       SOA     ns1.child.address03.xa. admin. (
+                2025022400      ; serial
+                6h              ; refresh
+                1h              ; retry
+                1w              ; expire
+                1d )            ; minimum
+
+                NS	ns1.child.address03.xa.
+                NS	ns15.child.address03.xa.

--- a/test-zone-data/Address-TP/address03/reverse-aliases.address03.xa.zone
+++ b/test-zone-data/Address-TP/address03/reverse-aliases.address03.xa.zone
@@ -1,0 +1,15 @@
+$ORIGIN reverse-aliases.address03.xa.            ; Must end with "."
+$TTL 3600
+
+@       SOA     ns1.child.address03.xa. admin. (
+                2025022400      ; serial
+                6h              ; refresh
+                1h              ; retry
+                1w              ; expire
+                1d )            ; minimum
+
+		NS	ns1.child.address03.xa.
+		NS	ns2.child.address03.xa.
+
+1-4-0-0         PTR     ns11.child.address03.xa.
+41              PTR     ns11.child.address03.xa.

--- a/test-zone-data/Address-TP/address03/test-zones-output.md
+++ b/test-zone-data/Address-TP/address03/test-zones-output.md
@@ -1,0 +1,219 @@
+# Address03 Test Zones Output
+
+# Table of contents
+* [Introduction](#introduction)
+* [All message tags](#all-message-tags)
+* [All scenarios](#all-scenarios)
+* [zonemaster-cli commands and their output for each test scenario](#zonemaster-cli-command-and-their-output-for-each-test-scenario)
+
+## Introduction
+
+In this file the output of running `zonemaster-cli` for every test zone is
+found. This file is created during the development of the test zones and should
+be updated as the implementation of the test case or the test scenarios or test
+zones are updated or corrected.
+
+During development and any update this document serves as tracking and log tool.
+It also serves as a template for future development of test zones for
+scenarios for other test cases.
+
+## All message tags
+
+* NAMESERVER\_IP\_PTR\_MATCH
+* NAMESERVER\_IP\_PTR\_MISMATCH
+* NAMESERVER\_IP\_WITHOUT\_REVERSE
+* NO\_RESPONSE\_PTR\_QUERY
+
+## All scenarios
+
+| Scenario name              | Zone name                               |
+|:---------------------------|:----------------------------------------|
+| ALL-NS-HAVE-PTR-1          | all-ns-have-ptr-1.address03.xa          |
+| ALL-NS-HAVE-PTR-2          | all-ns-have-ptr-2.address03.xa          |
+| NO-NS-HAVE-PTR             | no-ns-have-ptr.address03.xa             |
+| INCOMPLETE-PTR-1           | incomplete-ptr-1.address03.xa           |
+| INCOMPLETE-PTR-2           | incomplete-ptr-2.address03.xa           |
+| NON-MATCHING-NAMES         | non-matching-names.address03.xa         |
+| PTR-IS-GOOD-CNAME-1        | ptr-is-good-cname-1.address03.xa        |
+| PTR-IS-GOOD-CNAME-2        | ptr-is-good-cname-2.address03.xa        |
+| PTR-IS-DANGLING-CNAME      | ptr-is-dangling-cname.address03.xa      |
+| PTR-IS-ILLEGAL-CNAME       | ptr-is-illegal-cname.address03.xa       |
+| PTR-RESOLUTION-NO-RESPONSE | ptr-resolution-no-response.address03.xa |
+| PTR-RESOLUTION-SERVFAIL    | ptr-resolution-servfail.address03.xa    |
+
+
+## zonemaster-cli commands and their output for each test scenario
+
+The level (`--level`) must be set to the lowest level of the message tags. For
+this test case `INFO` is the lowest level. It is only meaningful to test the
+test zones with `--test Address03`.
+
+| Scenario name     | Mandatory message tag      | Forbidden message tags |
+|:------------------|:---------------------------|:-----------------------|
+| ALL-NS-HAVE-PTR-1 | NAMESERVER\_IP\_PTR\_MATCH | 2)                     |
+
+* (2) All tags except for those specified as “Mandatory message tags”
+
+```
+$ zonemaster-cli --raw --show-testcase --test address03 --hints COMMON/hintfile --level info all-ns-have-ptr-1.address03.xa
+   0.00 INFO     Unspecified    GLOBAL_VERSION  version=v7.0.0
+   0.10 INFO     Address03      NAMESERVER_IP_PTR_MATCH
+```
+--> OK
+
+| Scenario name     | Mandatory message tag      | Forbidden message tags |
+|:------------------|:---------------------------|:-----------------------|
+| ALL-NS-HAVE-PTR-2 | NAMESERVER\_IP\_PTR\_MATCH | 2)                     |
+
+* (2) All tags except for those specified as “Mandatory message tags”
+
+```
+$ zonemaster-cli --raw --show-testcase --test address03 --hints COMMON/hintfile --level info all-ns-have-ptr-2.address03.xa
+   0.00 INFO     Unspecified    GLOBAL_VERSION  version=v7.0.0
+   0.11 INFO     Address03      NAMESERVER_IP_PTR_MATCH
+```
+--> OK
+
+| Scenario name  | Mandatory message tag            | Forbidden message tags |
+|:---------------|:---------------------------------|:-----------------------|
+| NO-NS-HAVE-PTR | NAMESERVER\_IP\_WITHOUT\_REVERSE | 2)                     |
+
+* (2) All tags except for those specified as “Mandatory message tags”
+
+```
+$ zonemaster-cli --raw --show-testcase --test address03 --hints COMMON/hintfile --level info no-ns-have-ptr.address03.xa
+   0.00 INFO     Unspecified    GLOBAL_VERSION  version=v7.0.0
+   0.06 WARNING  Address03      NAMESERVER_IP_WITHOUT_REVERSE  ns_ip=127.11.3.34; nsname=ns4.child.address03.xa
+   0.07 WARNING  Address03      NAMESERVER_IP_WITHOUT_REVERSE  ns_ip=fda1:b2:c3:0:127:11:3:34; nsname=ns4.child.address03.xa
+   0.08 WARNING  Address03      NAMESERVER_IP_WITHOUT_REVERSE  ns_ip=127.11.3.35; nsname=ns5.child.address03.xa
+   0.09 WARNING  Address03      NAMESERVER_IP_WITHOUT_REVERSE  ns_ip=fda1:b2:c3:0:127:11:3:35; nsname=ns5.child.address03.xa
+```
+--> OK
+
+| Scenario name    | Mandatory message tag            | Forbidden message tags |
+|:-----------------|:---------------------------------|:-----------------------|
+| INCOMPLETE-PTR-1 | NAMESERVER\_IP\_WITHOUT\_REVERSE | 2)                     |
+
+* (2) All tags except for those specified as “Mandatory message tags”
+
+```
+$ zonemaster-cli --raw --show-testcase --test address03 --hints COMMON/hintfile --level info incomplete-ptr-1.address03.xa
+   0.00 INFO     Unspecified    GLOBAL_VERSION  version=v7.0.0
+   0.08 WARNING  Address03      NAMESERVER_IP_WITHOUT_REVERSE  ns_ip=127.11.3.36; nsname=ns6.child.address03.xa
+```
+--> OK
+
+| Scenario name    | Mandatory message tag            | Forbidden message tags |
+|:-----------------|:---------------------------------|:-----------------------|
+| INCOMPLETE-PTR-2 | NAMESERVER\_IP\_WITHOUT\_REVERSE | 2)                     |
+
+* (2) All tags except for those specified as “Mandatory message tags”
+
+```
+$ zonemaster-cli --raw --show-testcase --test address03 --hints COMMON/hintfile --level info incomplete-ptr-2.address03.xa
+   0.00 INFO     Unspecified    GLOBAL_VERSION  version=v7.0.0
+   0.07 WARNING  Address03      NAMESERVER_IP_WITHOUT_REVERSE  ns_ip=fda1:b2:c3:0:127:11:3:37; nsname=ns7.child.address03.xa
+```
+--> OK
+
+| Scenario name      | Mandatory message tag         | Forbidden message tags |
+|:-------------------|:------------------------------|:-----------------------|
+| NON-MATCHING-NAMES | NAMESERVER\_IP\_PTR\_MISMATCH | 2)                     |
+
+* (2) All tags except for those specified as “Mandatory message tags”
+
+```
+$ zonemaster-cli --raw --show-testcase --test address03 --hints COMMON/hintfile --level info non-matching-names.address03.xa
+   0.00 INFO     Unspecified    GLOBAL_VERSION  version=v7.0.0
+   0.11 NOTICE   Address03      NAMESERVER_IP_PTR_MISMATCH  names=a-naughty-nameserver.child.address03.xa.; ns_ip=127.11.3.38; nsname=ns8.child.address03.xa
+   0.12 NOTICE   Address03      NAMESERVER_IP_PTR_MISMATCH  names=a-naughty-nameserver.child.address03.xa.; ns_ip=fda1:b2:c3:0:127:11:3:38; nsname=ns8.child.address03.xa
+   0.13 NOTICE   Address03      NAMESERVER_IP_PTR_MISMATCH  names=non-matching-set-1.child.address03.xa./non-matching-set-2.child.address03.xa.; ns_ip=127.11.3.39; nsname=ns9.child.address03.xa
+   0.13 NOTICE   Address03      NAMESERVER_IP_PTR_MISMATCH  names=non-matching-set-1.child.address03.xa./non-matching-set-2.child.address03.xa.; ns_ip=fda1:b2:c3:0:127:11:3:39; nsname=ns9.child.address03.xa
+```
+--> OK
+
+| Scenario name       | Mandatory message tag      | Forbidden message tags |
+|:--------------------|:---------------------------|:-----------------------|
+| PTR-IS-GOOD-CNAME-1 | NAMESERVER\_IP\_PTR\_MATCH | 2)                     |
+
+* (2) All tags except for those specified as “Mandatory message tags”
+
+```
+$ zonemaster-cli --raw --show-testcase --test address03 --hints COMMON/hintfile --level info ptr-is-good-cname-1.address03.xa
+   0.00 INFO     Unspecified    GLOBAL_VERSION  version=v7.0.0
+   0.15 INFO     Address03      NAMESERVER_IP_PTR_MATCH
+```
+--> OK
+
+| Scenario name       | Mandatory message tag      | Forbidden message tags |
+|:--------------------|:---------------------------|:-----------------------|
+| PTR-IS-GOOD-CNAME-2 | NAMESERVER\_IP\_PTR\_MATCH | 2)                     |
+
+* (2) All tags except for those specified as “Mandatory message tags”
+
+```
+$ zonemaster-cli --raw --show-testcase --test address03 --hints COMMON/hintfile --level info ptr-is-good-cname-2.address03.xa
+   0.00 INFO     Unspecified    GLOBAL_VERSION  version=v7.0.0
+   0.14 WARNING  Address03      NAMESERVER_IP_WITHOUT_REVERSE  ns_ip=127.11.3.41; nsname=ns11.child.address03.xa
+   0.16 WARNING  Address03      NAMESERVER_IP_WITHOUT_REVERSE  ns_ip=fda1:b2:c3:0:127:11:3:41; nsname=ns11.child.address03.xa
+```
+
+The output is incorrect with Zonemaster-Engine version 7.0.0 due to a bug (<https://github.com/zonemaster/zonemaster/issues/1353>).
+
+--> Not yet OK
+
+| Scenario name         | Mandatory message tag            | Forbidden message tags |
+|:----------------------|:---------------------------------|:-----------------------|
+| PTR-IS-DANGLING-CNAME | NAMESERVER\_IP\_WITHOUT\_REVERSE | 2)                     |
+
+* (2) All tags except for those specified as “Mandatory message tags”
+
+```
+$ zonemaster-cli --raw --show-testcase --test address03 --hints COMMON/hintfile --level info ptr-is-dangling-cname.address03.xa
+   0.00 INFO     Unspecified    GLOBAL_VERSION  version=v7.0.0
+   0.07 WARNING  Address03      NAMESERVER_IP_WITHOUT_REVERSE  ns_ip=127.11.3.42; nsname=ns12.child.address03.xa
+   0.08 WARNING  Address03      NAMESERVER_IP_WITHOUT_REVERSE  ns_ip=fda1:b2:c3:0:127:11:3:42; nsname=ns12.child.address03.xa
+   0.08 WARNING  Address03      NAMESERVER_IP_WITHOUT_REVERSE  ns_ip=127.11.3.35; nsname=ns5.child.address03.xa
+   0.09 WARNING  Address03      NAMESERVER_IP_WITHOUT_REVERSE  ns_ip=fda1:b2:c3:0:127:11:3:35; nsname=ns5.child.address03.xa
+```
+--> OK
+
+| Scenario name        | Mandatory message tag            | Forbidden message tags                                    |
+|:---------------------|:---------------------------------|:----------------------------------------------------------|
+| PTR-IS-ILLEGAL-CNAME | NAMESERVER\_IP\_WITHOUT\_REVERSE | NAMESERVER\_IP\_PTR\_MATCH, NAMESERVER\_IP\_PTR\_MISMATCH |
+
+```
+$ zonemaster-cli --raw --show-testcase --test address03 --hints COMMON/hintfile --level info ptr-is-illegal-cname.address03.xa
+   0.00 INFO     Unspecified    GLOBAL_VERSION  version=v7.0.0
+   0.06 ERROR    Address03      CNAME_RECORDS_MULTIPLE_FOR_NAME  name="43.3.11.127.in-addr.arpa"
+   0.06 WARNING  Address03      NO_RESPONSE_PTR_QUERY  domain=43.3.11.127.in-addr.arpa.
+   0.06 ERROR    Address03      CNAME_RECORDS_MULTIPLE_FOR_NAME  name="3.4.0.0.3.0.0.0.1.1.0.0.7.2.1.0.0.0.0.0.3.c.0.0.2.b.0.0.1.a.d.f.ip6.arpa"
+   0.06 WARNING  Address03      NO_RESPONSE_PTR_QUERY  domain=3.4.0.0.3.0.0.0.1.1.0.0.7.2.1.0.0.0.0.0.3.c.0.0.2.b.0.0.1.a.d.f.ip6.arpa.
+   0.07 WARNING  Address03      NAMESERVER_IP_WITHOUT_REVERSE  ns_ip=127.11.3.34; nsname=ns4.child.address03.xa
+   0.07 WARNING  Address03      NAMESERVER_IP_WITHOUT_REVERSE  ns_ip=fda1:b2:c3:0:127:11:3:34; nsname=ns4.child.address03.xa
+```
+--> OK
+
+| Scenario name              | Mandatory message tag    | Forbidden message tags                                    |
+|:---------------------------|:-------------------------|:----------------------------------------------------------|
+| PTR-RESOLUTION-NO-RESPONSE | NO\_RESPONSE\_PTR\_QUERY | NAMESERVER\_IP\_PTR\_MATCH, NAMESERVER\_IP\_PTR\_MISMATCH |
+
+```
+$ zonemaster-cli --raw --show-testcase --test address03 --hints COMMON/hintfile --level info ptr-resolution-no-response.address03.xa
+   0.00 INFO     Unspecified    GLOBAL_VERSION  version=v7.0.0
+  40.12 WARNING  Address03      NO_RESPONSE_PTR_QUERY  domain=44.3.11.127.in-addr.arpa.
+  40.12 WARNING  Address03      NO_RESPONSE_PTR_QUERY  domain=4.4.0.0.3.0.0.0.1.1.0.0.7.2.1.0.0.0.0.0.3.c.0.0.2.b.0.0.1.a.d.f.ip6.arpa.
+```
+--> OK
+
+| Scenario name           | Mandatory message tag    | Forbidden message tags                                    |
+|:------------------------|:-------------------------|:----------------------------------------------------------|
+| PTR-RESOLUTION-SERVFAIL | NO\_RESPONSE\_PTR\_QUERY | NAMESERVER\_IP\_PTR\_MATCH, NAMESERVER\_IP\_PTR\_MISMATCH |
+
+```
+$ zonemaster-cli --raw --show-testcase --test address03 --hints COMMON/hintfile --level info ptr-resolution-servfail.address03.xa
+   0.00 INFO     Unspecified    GLOBAL_VERSION  version=v7.0.0
+   0.07 WARNING  Address03      NAMESERVER_IP_WITHOUT_REVERSE  ns_ip=127.11.3.45; nsname=ns15.child.address03.xa
+   0.08 WARNING  Address03      NAMESERVER_IP_WITHOUT_REVERSE  ns_ip=fda1:b2:c3:0:127:11:3:45; nsname=ns15.child.address03.xa
+```
+--> Not yet OK

--- a/test-zone-data/COMMON/arpa
+++ b/test-zone-data/COMMON/arpa
@@ -29,6 +29,13 @@ $ORIGIN 12.0.2.127.in-addr.arpa.
 $ORIGIN 2.1.0.0.0.0.0.0.2.0.0.0.7.2.1.0.0.0.0.0.3.c.0.0.2.b.0.0.1.a.d.f.ip6.arpa.
 @                       PTR  ns2.xa.
 
+$ORIGIN 3.11.127.in-addr.arpa.
+@                       NS   ns1.address03.xa.
+@                       NS   ns2.address03.xa.
+$ORIGIN 3.0.0.0.1.1.0.0.7.2.1.0.0.0.0.0.3.c.0.0.2.b.0.0.1.a.d.f.ip6.arpa.
+@                       NS   ns1.address03.xa.
+@                       NS   ns2.address03.xa.
+
 $ORIGIN 21.9.19.127.in-addr.arpa.
 @                       PTR  ns1.zone09.xa.
 $ORIGIN 1.2.0.0.9.0.0.0.9.1.0.0.7.2.1.0.0.0.0.0.3.c.0.0.2.b.0.0.1.a.d.f.ip6.arpa.

--- a/test-zone-data/COMMON/xa
+++ b/test-zone-data/COMMON/xa
@@ -19,6 +19,16 @@ ns2     AAAA  fda1:b2:c3::127:2:0:12
 
 ;;;; Test case based
 
+;; Address-TP
+
+$ORIGIN address03.xa.    ; Must be FQDN
+@               NS      ns1
+@               NS      ns2
+ns1             A       127.11.3.21
+ns1             AAAA    fda1:b2:c3:0:127:11:3:21
+ns2             A       127.11.3.22
+ns2             AAAA    fda1:b2:c3:0:127:11:3:22
+
 ;; Basic-TP
 
 $ORIGIN basic01.xa.      ; Must be FQDN

--- a/test-zone-data/README.md
+++ b/test-zone-data/README.md
@@ -192,7 +192,7 @@ data.
 
 ### Test case based test zones
 
-* Address-TP/ (*not yet available*)
+* [Address-TP/]
   * Directory structure for scenarios for test cases in the Address-TP test module.
 * [Basic-TP/]
   * Directory structure for scenarios for test cases in the Basic-TP test module.
@@ -227,6 +227,7 @@ data.
 
 
 [address-plan.md]:                                     address-plan.md
+[Address-TP/]:                                         Address-TP/
 [Basic-TP/]:                                           Basic-TP/
 [COMMON/]:                                             COMMON/
 [Consistency-TP/]:                                     Consistency-TP/

--- a/test-zone-data/address-plan.md
+++ b/test-zone-data/address-plan.md
@@ -128,6 +128,21 @@ Follow the same pattern as in use by adding the address without prefix, e.g. as
 | 127.11.3.0/24   | Address03 scenarios                                         |
 | 127.11.3.21     | ns1.address03.xa                                            |
 | 127.11.3.22     | ns2.address03.xa                                            |
+| 127.11.3.31     | ns1.child.address03.xa                                      |
+| 127.11.3.32     | ns2.child.address03.xa                                      |
+| 127.11.3.33     | ns3.child.address03.xa                                      |
+| 127.11.3.34     | ns4.child.address03.xa                                      |
+| 127.11.3.35     | ns5.child.address03.xa                                      |
+| 127.11.3.36     | ns6.child.address03.xa                                      |
+| 127.11.3.37     | ns7.child.address03.xa                                      |
+| 127.11.3.38     | ns8.child.address03.xa                                      |
+| 127.11.3.39     | ns9.child.address03.xa                                      |
+| 127.11.3.40     | ns10.child.address03.xa                                     |
+| 127.11.3.41     | ns11.child.address03.xa                                     |
+| 127.11.3.42     | ns12.child.address03.xa                                     |
+| 127.11.3.43     | ns13.child.address03.xa                                     |
+| 127.11.3.44     | ns14.child.address03.xa                                     |
+| 127.11.3.45     | ns15.child.address03.xa                                     |
 | 127.11.4.0/24   | (not in use)                                                |
 | (...)           |                                                             |
 | 127.11.255.0/24 | (not in use)                                                |

--- a/test-zone-data/main.cfg
+++ b/test-zone-data/main.cfg
@@ -54,6 +54,8 @@ xb. {
 
 # Include test case specific configuration
 #
+# Address-TP
+import Address-TP/address03/address03.cfg
 # Basic-TP
 import Basic-TP/basic01/basic01.cfg
 # Connectivity-TP


### PR DESCRIPTION
## Purpose

This PR adds a handful of test scenarios in order to test the current implementation of Address03.

The test scenarios involve empty zones (except for SOA and NS resource records at the apex), with varying name servers which themselves have addresses which may or may not have associated PTR resource records.

## Context

Attempt to reproduce the issue in #1353.

## Changes

* Add Address03 test data and documentation

## How to test this PR

N/A
