### PR TITLE
Remove 'Randomized capitalization' documentation

### DIFF
--- a/docs/public/installation/zonemaster-ldns.md
+++ b/docs/public/installation/zonemaster-ldns.md
@@ -69,16 +69,6 @@ When enabled, an included version of ldns is statically linked into
 Zonemaster::LDNS.
 When disabled, libldns is dynamically linked just like other dependencies.
 
-#### Randomized capitalization
-
-Disabled by default.
-Enable with `--randomize`.
-
-> **Note:** This feature is experimental.
-
-Randomizes the capitalization of returned domain names.
-
-
 #### Custom OpenSSL
 
 Disabled by default.


### PR DESCRIPTION
## Purpose

This PR removes the documentation related to the "Randomized capitalization" feature of Zonemaster-LDNS.

## Context

v2025.1 release testing
Feature was removed by https://github.com/zonemaster/zonemaster-ldns/pull/207

## Changes

- docs/public/installation/zonemaster-ldns.md

## How to test this PR

N/A.
