### PR TITLE
Editorial update of installation instruction

### DIFF
--- a/docs/public/installation/zonemaster-backend.md
+++ b/docs/public/installation/zonemaster-backend.md
@@ -103,9 +103,6 @@ Install Zonemaster::Backend:
 sudo cpanm --notest Zonemaster::Backend
 ```
 
-> The command above might try to install "DBD::Pg" and "DBD::mysql".
-> You can ignore if it fails. The relevant libraries are installed further down in these instructions.
-
 Add Zonemaster user (unless it already exists):
 
 ```sh
@@ -243,9 +240,6 @@ Install Zonemaster::Backend:
 ```sh
 sudo cpanm --notest Zonemaster::Backend
 ```
-
-> The command above might try to install "DBD::Pg" and "DBD::mysql".
-> You can ignore if it fails. The relevant libraries are installed further down in these instructions.
 
 Add Zonemaster user (unless it already exists):
 


### PR DESCRIPTION
## Purpose

1. This PR removes unneeded text for FreeBSD installation to make it easier to read. The command never tries to install the DB libraries. It did years ago.
2. Updates information on PostgreSQL version for FreeBSD.
3. Removes old "warning" not relevant anymore. Same as in 1. but for the other OSs.

## How to test this PR

Review.