### PR TITLE
Updates issue labels

### DIFF
--- a/docs/internal/maintenance/IssueLabels.md
+++ b/docs/internal/maintenance/IssueLabels.md
@@ -31,7 +31,7 @@ be combined with any other *Release category* label.
 
 ## Labels
 
-Category         | Label              | Color   | Used in repository | Scope |Description
+Category         | Label              | Color   | Used in repository | Scope | Description
 -----------------|--------------------|---------|--------------------|-------|---------------------------------------------------------
 Area             | A-Documentation    | green   | all                | Both  | Area: Documentation only.
 Area             | A-TestCase         | green   | main or Engine     | Both  | Area: Test case specification or implementation of test case.
@@ -52,7 +52,9 @@ Versioning       | V-Major            | pink    | all but main       | Both  | V
 Versioning       | V-Minor            | pink    | all but main       | Both  | Versioning: The change gives an update of minor in version.
 Versioning       | V-Patch            | pink    | all but main       | Both  | Versioning: The change gives an update of patch in version.
 
-## Color
+### Color
+
+In the table above, the following terms for "Color" are defined:
 
 Term     | Color code
 ---------|---------------------------------------------
@@ -63,14 +65,19 @@ red      | #EE0701
 yellow   | #FFCE2E
 magenta  | #D4C5F9
 
-## Used in repository
+### Used in repository
+
+In the table above, the following terms for "Used in repository" are defined:
 
 Term     | Definition or meaning
 ---------|---------------------------------------------
-main     | In the table above, "main" stands for the [Zonemaster/Zonemaster] repository
-Engine   | In the table above, "Engine" stands for the [Zonemaster-Engine] repository
+all      | Stands for the [Zonemaster/Zonemaster], [Zonemaster-LDNS], [Zonemaster-Engine], [Zonemaster-CLI], [Zonemaster-Backend] and [Zonemaster-GUI] repositories
+main     | Stands for the [Zonemaster/Zonemaster] repository
+Engine   | Stands for the [Zonemaster-Engine] repository
 
-## Scope
+### Scope
+
+In the table above, the following terms for "Scope" are defined:
 
 Term  | Definition or meaning
 ------|---------------------------------------------------
@@ -79,4 +86,8 @@ Issue | The label is meant for Issue only
 Both  | The label is meant for both Pull Request and Issue
 
 [Zonemaster/Zonemaster]:    https://github.com/zonemaster/zonemaster
+[Zonemaster-LDNS]:          https://github.com/zonemaster/zonemaster-ldns
 [Zonemaster-Engine]:        https://github.com/zonemaster/zonemaster-engine
+[Zonemaster-CLI]:           https://github.com/zonemaster/zonemaster-cli
+[Zonemaster-Backend]:       https://github.com/zonemaster/zonemaster-backend
+[Zonemaster-GUI]:           https://github.com/zonemaster/zonemaster-gui


### PR DESCRIPTION
## Purpose

* Removes FA-MethodsV2 not relevant.
* Adds Release category labels.
* Editorial updates.

The proposed label setup has been configured in https://github.com/matsduf/zonemaster/labels (fork of the repository). There are some test issues with the labels in https://github.com/matsduf/zonemaster/issues.

On meeting we agreed to use pink, that same color as for *Versioning* labels, on the new *Release category* labels. After doing the configuration in the fork I felt that a contrast is needed, and changed color to magenta in the specification. In the fork three of five  *Release category* labels still have the pink color.

In https://github.com/matsduf/zonemaster/issues/6 different colors are used. In https://github.com/matsduf/zonemaster/issues/4 the same color is used. The difference is to give the possibility to evaluate what is best. All *Release category* labels should have the same color.

*Versioning* labels do not do not apply for the main repository.

## How to test this PR

Please comment if the same or different colors should be used. If different, please comment if the selected magenta color is good enough, or suggest another color.

Please also add other comments.