### PR TITLE
Fix Consistency06 test scenario MULT-SOA-MNAMES-NO-DEL-UNDEL-2

### DIFF
--- a/docs/public/specifications/test-zones/Consistency-TP/consistency06.md
+++ b/docs/public/specifications/test-zones/Consistency-TP/consistency06.md
@@ -141,11 +141,11 @@ the servers. NS are out-of-bailiwick.
 * Zone: mult-soa-mnames-no-del-undel-2.consistency06.xa.
   * NS are out-of-bailiwick, "ns3.mult-soa-mnames-no-del-undel-2.consistency06.xb"
     and "ns4.mult-soa-mnames-no-del-undel-2.consistency06.xb".
-  * MNAME in SOA on ns1 equal to ns1
-  * MNAME in SOA on ns2 equal to ns2
+  * MNAME in SOA on ns3 equal to ns3
+  * MNAME in SOA on ns4 equal to ns4
   * Undelegated data:
     * ns3.mult-soa-mnames-no-del-undel-2.consistency06.xb
-    * ns3.mult-soa-mnames-no-del-undel-2.consistency06.xb
+    * ns4.mult-soa-mnames-no-del-undel-2.consistency06.xb
 
 ### NO-RESPONSE
 No name server responds.

--- a/test-zone-data/COMMON/xb
+++ b/test-zone-data/COMMON/xb
@@ -28,9 +28,9 @@ ns2     AAAA  fda1:b2:c3::127:14:5:24
 $ORIGIN consistency06.xb.
 @       NS    ns1
 @       NS    ns2
-ns1	A     127.14.5.23
-ns1     AAAA  fda1:b2:c3::127:14:5:23
-ns2     A     127.14.5.24
-ns2     AAAA  fda1:b2:c3::127:14:5:24
+ns1     A     127.14.6.23
+ns1     AAAA  fda1:b2:c3::127:14:6:23
+ns2     A     127.14.6.24
+ns2     AAAA  fda1:b2:c3::127:14:6:24
 
 ;EOF

--- a/test-zone-data/Consistency-TP/consistency06/README.md
+++ b/test-zone-data/Consistency-TP/consistency06/README.md
@@ -147,16 +147,17 @@ MULT-SOA-MNAMES-NO-DEL-UNDEL-2 | MULTIPLE_SOA_MNAMES                  | NO_RESPO
 
 * Undelegated data:
   * ns3.mult-soa-mnames-no-del-undel-2.consistency06.xb
-  * ns3.mult-soa-mnames-no-del-undel-2.consistency06.xb
+  * ns4.mult-soa-mnames-no-del-undel-2.consistency06.xb
 ```
-$ zonemaster-cli MULT-SOA-MNAMES-NO-DEL-UNDEL-2.consistency06.xa --raw  --test consistency06 --hints COMMON/hintfile --show-testcase  --level info --profile COMMON/custom-profile.json --ns ns3.mult-soa-mnames-no-del-undel-2.consistency06.xb --ns ns3.mult-soa-mnames-no-del-undel-2.consistency06.xb
+$ zonemaster-cli MULT-SOA-MNAMES-NO-DEL-UNDEL-2.consistency06.xa --raw  --test consistency06 --hints COMMON/hintfile --show-testcase  --level info --profile COMMON/custom-profile.json --ns ns3.mult-soa-mnames-no-del-undel-2.consistency06.xb --ns ns4.mult-soa-mnames-no-del-undel-2.consistency06.xb
 Loading profile from COMMON/custom-profile.json.
-   0.43 ERROR    Unspecified    FAKE_DELEGATION_NO_IP  domain=mult-soa-mnames-no-del-undel-2.consistency06.xa; nsname=ns3.mult-soa-mnames-no-del-undel-2.consistency06.xb
-   0.00 INFO     Unspecified    GLOBAL_VERSION  version=v5.0.0
+   0.17 ERROR    Unspecified    FAKE_DELEGATION_NO_IP  domain=mult-soa-mnames-no-del-undel-2.consistency06.xa; nsname=ns3.mult-soa-mnames-no-del-undel-2.consistency06.xb
+   0.17 ERROR    Unspecified    FAKE_DELEGATION_NO_IP  domain=mult-soa-mnames-no-del-undel-2.consistency06.xa; nsname=ns4.mult-soa-mnames-no-del-undel-2.consistency06.xb
+   0.00 INFO     Unspecified    GLOBAL_VERSION  version=v8.0.0
    0.00 INFO     Consistency06  TEST_CASE_START  testcase=Consistency06
-   0.06 INFO     Consistency06  TEST_CASE_END  testcase=Consistency06
+   0.03 INFO     Consistency06  TEST_CASE_END  testcase=Consistency06
 ```
---> Not OK. FAKE_DELEGATION_NO_IP is not expected here.
+--> Not OK. MULTIPLE_SOA_MNAMES is not outputted and FAKE_DELEGATION_NO_IP is not expected here.
 
 Scenario name         | Mandatory message tags                            | Forbidden message tags
 :---------------------|:--------------------------------------------------|:-------------------------------------------

--- a/test-zone-data/Consistency-TP/consistency06/README.md
+++ b/test-zone-data/Consistency-TP/consistency06/README.md
@@ -160,7 +160,7 @@ Loading profile from COMMON/custom-profile.json.
 
 Scenario name         | Mandatory message tags                            | Forbidden message tags
 :---------------------|:--------------------------------------------------|:-------------------------------------------
-NO-RESPONSE           | NO-RESPONSE                                       | NO_RESPONSE_SOA_QUERY, MULTIPLE_SOA_MNAMES, ONE_SOA_MNAME
+NO-RESPONSE           | NO_RESPONSE                                       | NO_RESPONSE_SOA_QUERY, MULTIPLE_SOA_MNAMES, ONE_SOA_MNAME
 ```
 $ zonemaster-cli NO-RESPONSE.consistency06.xa --raw  --test Consistency/consistency06 --hints COMMON/hintfile --show-testcase  --level info --profile COMMON/custom-profile.json
 Loading profile from COMMON/custom-profile.json.

--- a/test-zone-data/Consistency-TP/consistency06/README.md
+++ b/test-zone-data/Consistency-TP/consistency06/README.md
@@ -151,13 +151,12 @@ MULT-SOA-MNAMES-NO-DEL-UNDEL-2 | MULTIPLE_SOA_MNAMES                  | NO_RESPO
 ```
 $ zonemaster-cli MULT-SOA-MNAMES-NO-DEL-UNDEL-2.consistency06.xa --raw  --test consistency06 --hints COMMON/hintfile --show-testcase  --level info --profile COMMON/custom-profile.json --ns ns3.mult-soa-mnames-no-del-undel-2.consistency06.xb --ns ns4.mult-soa-mnames-no-del-undel-2.consistency06.xb
 Loading profile from COMMON/custom-profile.json.
-   0.17 ERROR    Unspecified    FAKE_DELEGATION_NO_IP  domain=mult-soa-mnames-no-del-undel-2.consistency06.xa; nsname=ns3.mult-soa-mnames-no-del-undel-2.consistency06.xb
-   0.17 ERROR    Unspecified    FAKE_DELEGATION_NO_IP  domain=mult-soa-mnames-no-del-undel-2.consistency06.xa; nsname=ns4.mult-soa-mnames-no-del-undel-2.consistency06.xb
    0.00 INFO     Unspecified    GLOBAL_VERSION  version=v8.0.0
    0.00 INFO     Consistency06  TEST_CASE_START  testcase=Consistency06
+   0.03 NOTICE   Consistency06  MULTIPLE_SOA_MNAMES  count=2
    0.03 INFO     Consistency06  TEST_CASE_END  testcase=Consistency06
 ```
---> Not OK. MULTIPLE_SOA_MNAMES is not outputted and FAKE_DELEGATION_NO_IP is not expected here.
+--> OK
 
 Scenario name         | Mandatory message tags                            | Forbidden message tags
 :---------------------|:--------------------------------------------------|:-------------------------------------------

--- a/test-zone-data/Consistency-TP/consistency06/consistency06.cfg
+++ b/test-zone-data/Consistency-TP/consistency06/consistency06.cfg
@@ -14,14 +14,14 @@
     file Consistency-TP/consistency06/consistency06.xa.zone consistency06.xa
 }
 
-# consistency05.xb
-consistency05.xb.53 {
+# consistency06.xb
+consistency06.xb:53 {
     bind 127.14.6.23               # ns1
     bind fda1:b2:c3:0:127:14:6:23  # ns1
     bind 127.14.6.24               # ns2
     bind fda1:b2:c3:0:127:14:6:24  # ns2
     log
-    file Consistency-TP/consistency05/consistency05.xb.zone consistency06.xb
+    file Consistency-TP/consistency06/consistency06.xb.zone consistency06.xb
 }
 
 ### ==== Scenarios Consistency06 ====

--- a/test-zone-data/Consistency-TP/consistency06/consistency06.cfg
+++ b/test-zone-data/Consistency-TP/consistency06/consistency06.cfg
@@ -76,7 +76,7 @@ one-soa-mname-4.consistency06.xa:53 {
     log
     file Consistency-TP/consistency06/ns1.one-soa-mname-4.consistency06.xa.zone one-soa-mname-4.consistency06.xa
 }
-# ns1
+# ns2
 one-soa-mname-4.consistency06.xa:53 {
     bind 127.14.6.32
     bind fda1:b2:c3:0:127:14:6:32


### PR DESCRIPTION
## Purpose

This PR fixes a handful of minor errors in a test scenario for Consistency06, in the specification and the configuration files that implement it. Together, they prevented the correct operation of scenario MULT-SOA-MNAMES-NO-DEL-UNDEL-2.

## Context

Refactoring of Zonemaster-Engine unit tests.

## Changes

- Fix the test scenario specification;
- Fix the test scenario implementation (CoreDNS configuration and zone files);
- Update the sample `zonemaster-cli` output.

## How to test this PR

N/A.
