### PR TITLE
Zone11: different handling of root zone, TLD zones and zones in .arpa

### DIFF
--- a/docs/public/specifications/tests/Zone-TP/zone11.md
+++ b/docs/public/specifications/tests/Zone-TP/zone11.md
@@ -83,9 +83,10 @@ severity level can be changed in the [Zonemaster-Engine profile]. Also see the
 The argument names in the Arguments column lists the arguments used in the
 message. The argument names are defined in the [argument list].
 
-The name server names are assumed to be available at the time when the msgid
-is created, if the argument name is "ns_list" even when in the "[Test
-procedure]" below it is only referred to the IP address of the name servers.
+Name servers may have multiple IP addresses bound to the same name, and the
+same IP address may be used by multiple name server names. Message tags whose
+argument lists include "ns_list" shall contain all such name and IP address
+pairs.
 
 ## Test procedure
 
@@ -137,51 +138,57 @@ same specification.
 5. If the *SPF-Policies* set is empty, then output
    *[Z11_UNABLE_TO_CHECK_FOR_SPF]* and terminate the test.
 
-6. If all the pairs in the *SPF-Policies* set contain empty strings, then:
+6. If all the name server IPs in the *SPF-Policies* set contain empty strings
+   (no "SPF policy"), then:
 
    1. If the *Child Zone* is the root zone ("."), a [TLD] or a zone under
-      .ARPA, then output *[Z11_NO_SPF_NON_MAIL_DOMAIN]* and terminate the
-      test.
+      .ARPA, then output *[Z11_NO_SPF_NON_MAIL_DOMAIN]* for *Child Zone* and
+      terminate the test.
 
-   2. Else, output *[Z11_NO_SPF_FOUND]* and terminate the test.
+   2. Else, output *[Z11_NO_SPF_FOUND]* for *Child Zone* and terminate the
+      test.
 
 7. For all messages outputted below, if an IP address in *Name Servers* is
    connected to more than one name server name, then all names should be
    included with the message tag.
 
-8. Compare the set of *SPF-Policies* retrieved from all name servers. If at
-   least two different name servers have returned different sets of SPF
-   policies, then:
+8. Compare the set of *SPF-Policies* retrieved from all name servers (in the
+   *SPF-Policies* set). If at least two different name servers have returned
+   different sets of SPF policies, then:
 
    1. Output *[Z11_INCONSISTENT_SPF_POLICIES]*.
    2. Group *SPF-Policies* by equal sets of SPF policies, such that a set of
       SPF policies is mapped to the list of *Name Servers* that returned it.
    3. For each such group of name servers, output
-      *[Z11_DIFFERENT_SPF_POLICIES_FOUND]*.
+      *[Z11_DIFFERENT_SPF_POLICIES_FOUND]* with the set of name servers
+      ("ns_list") in the group.
    4. Terminate the test.
 
 9. If the *SPF-Policies* set contains at least two entries with the same IP
    address, then output *[Z11_SPF_MULTIPLE_RECORDS]* with the list of
-   nameservers that returned more than one SPF policy and terminate the test.
+   name servers that returned more than one SPF policy and terminate the test.
 
-10. The following steps assume that all pairs in the *SPF-Policies* set have
-    the same string ("SPF policy").
+10. The following steps assume that all name server IPs in the *SPF-Policies*
+    set have the same string ("SPF policy").
 
 11. If the *SPF Policy* does not [pass the syntax check][passing the syntax
-    check] for SPF records, then output *[Z11_SPF_SYNTAX_ERROR]* and terminate
-    the test.
+    check] for SPF records, then output *[Z11_SPF_SYNTAX_ERROR]* for *Child
+    Zone* and the set of name servers from which the *SPF Policy* was
+    retrieved, and terminate the test.
 
 12. If the *Child Zone* is the root zone ("."), a [TLD] or a zone under
     .ARPA, then:
 
-   1. If the *SPF Policy* is a [Null SPF] policy, then output
-      *[Z11_NULL_SPF_NON_MAIL_DOMAIN]* and terminate the test.
+    1. If the *SPF Policy* is a [Null SPF] policy, then output
+       *[Z11_NULL_SPF_NON_MAIL_DOMAIN]* for *Child Zone* and terminate the
+       test.
 
-   2. If the *SPF Policy* is not a [Null SPF] policy, then output
-      *[Z11_NON_NULL_SPF_NON_MAIL_DOMAIN]* and terminate the test.
+    2. If the *SPF Policy* is not a [Null SPF] policy, then output
+       *[Z11_NON_NULL_SPF_NON_MAIL_DOMAIN]* for *Child Zone* and terminate the
+       test.
 
 13. If no other message was outputted by this test case, then output
-    *[Z11_SPF_SYNTAX_OK]*.
+    *[Z11_SPF_SYNTAX_OK]* for *Child Zone*.
 
 ## Outcome(s)
 

--- a/docs/public/specifications/tests/Zone-TP/zone11.md
+++ b/docs/public/specifications/tests/Zone-TP/zone11.md
@@ -71,10 +71,10 @@ Z11_NO_SPF_FOUND                 | NOTICE  | domain          | No SPF policy was
 Z11_NO_SPF_NON_MAIL_DOMAIN       | INFO    | domain          | No SPF policy was found for {domain}, which is a type of domain (root, TLD or under .ARPA) not expected to be used for email.
 Z11_NON_NULL_SPF_NON_MAIL_DOMAIN | NOTICE  | domain          | A non-null SPF policy was found on {domain}, although this type of domain (root, TLD or under .ARPA) is not expected to be used for email.
 Z11_NULL_SPF_NON_MAIL_DOMAIN     | INFO    | domain          | A null SPF policy was found on {domain}, which is a type of domain (root, TLD or under .ARPA) not expected to be used for email.
-Z11_SPF_MULTIPLE_RECORDS         | ERROR   | ns_list         | The following name servers returned more than one SPF policy. Name servers: {ns_list}.
-Z11_SPF_SYNTAX_ERROR             | ERROR   | domain, ns_list | The SPF policy of {domain} has a syntax error. Policy retrieved from the following nameservers: {ns_list}.
+Z11_SPF_MULTIPLE_RECORDS         | WARNING | ns_list         | The following name servers returned more than one SPF policy. Name servers: {ns_list}.
+Z11_SPF_SYNTAX_ERROR             | WARNING | domain, ns_list | The SPF policy of {domain} has a syntax error. Policy retrieved from the following nameservers: {ns_list}.
 Z11_SPF_SYNTAX_OK                | INFO    | domain          | The SPF policy of {domain} has correct syntax.
-Z11_UNABLE_TO_CHECK_FOR_SPF      | ERROR   |                 | None of the zone’s name servers responded with an authoritative response to queries for SPF policies.
+Z11_UNABLE_TO_CHECK_FOR_SPF      | WARNING |                 | None of the zone’s name servers responded with an authoritative response to queries for SPF policies.
 
 The value in the Level column is the default severity level of the message. The
 severity level can be changed in the [Zonemaster-Engine profile]. Also see the

--- a/docs/public/specifications/tests/Zone-TP/zone11.md
+++ b/docs/public/specifications/tests/Zone-TP/zone11.md
@@ -17,14 +17,14 @@
 
 ## Objective
 
-Sender Policy Framework (SPF), described in [RFC 7208], is a mechanism
+Sender Policy Framework (SPF) version 1, defined in [RFC 7208], is a mechanism
 allowing domain name owners to specify which hosts are allowed to send mail
-claiming to be from that domain. It is implemented by means of TXT records in a
-structured format.
+claiming to be from that domain. It is implemented by means of TXT records in
+a structured format.
 
 This test case looks up SPF records in the apex of *Child Zone*. It checks
-that there is at most one published SPF version 1 policy and, if present, also
-checks its syntax.
+that there is at most one published SPF policy and, if present, also checks
+its syntax.
 
 ## Scope
 
@@ -41,12 +41,12 @@ server.
 
 Message Tag                      | Level   | Arguments          | Message ID for message tag
 :--------------------------------|:--------|:-------------------|:--------------------------------------------
+Z11_DIFFERENT_SPF_POLICIES_FOUND | NOTICE  | ns_ip_list         | The following name servers returned the same SPF policy. Name servers: {ns_ip_list}.
 Z11_INCONSISTENT_SPF_POLICIES    | WARNING |                    | One or more name servers do not publish the same SPF policy as the others.
-Z11_DIFFERENT_SPF_POLICIES_FOUND | NOTICE  | ns_ip_list         | The following name servers returned the same SPF policy, but other name servers returned a different policy. Name servers: {ns_ip_list}.
 Z11_NO_SPF_FOUND                 | NOTICE  | domain             | No SPF policy was found for {domain}.
-Z11_SPF1_MULTIPLE_RECORDS        | ERROR   | ns_ip_list         | The following name servers returned more than one SPF policy. Name servers: {ns_ip_list}.
-Z11_SPF1_SYNTAX_ERROR            | ERROR   | domain, ns_ip_list | The SPF policy of {domain} has a syntax error. Policy retrieved from the following nameservers: {ns_ip_list}.
-Z11_SPF1_SYNTAX_OK               | INFO    | domain             | The SPF policy of {domain} has correct syntax.
+Z11_SPF_MULTIPLE_RECORDS         | ERROR   | ns_ip_list         | The following name servers returned more than one SPF policy. Name servers: {ns_ip_list}.
+Z11_SPF_SYNTAX_ERROR             | ERROR   | domain, ns_ip_list | The SPF policy of {domain} has a syntax error. Policy retrieved from the following nameservers: {ns_ip_list}.
+Z11_SPF_SYNTAX_OK                | INFO    | domain             | The SPF policy of {domain} has correct syntax.
 Z11_UNABLE_TO_CHECK_FOR_SPF      | ERROR   |                    | None of the zone’s name servers responded with an authoritative response to queries for SPF policies.
 
 The value in the Level column is the default severity level of the message. The
@@ -119,18 +119,18 @@ same specification.
    4. Terminate the test.
 
 8. If the *SPF-Policies* set contains at least two entries with the same IP
-   address, then output *[Z11_SPF1_MULTIPLE_RECORDS]* with the list of
+   address, then output *[Z11_SPF_MULTIPLE_RECORDS]* with the list of
    nameservers that returned more than one SPF policy and terminate the test.
 
 9. The following steps assume that all pairs in the *SPF-Policies* set have
    the same string ("SPF policy").
 
 10. If the *SPF Policy* does not [pass the syntax check][passing the syntax
-    check] for SPF version 1 records, then output *[Z11_SPF1_SYNTAX_ERROR]* and
-    terminate the test.
+    check] for SPF records, then output *[Z11_SPF_SYNTAX_ERROR]* and terminate
+    the test.
 
 11. If no other message was outputted by this test case, then output
-    *[Z11_SPF1_SYNTAX_OK]*.
+    *[Z11_SPF_SYNTAX_OK]*.
 
 ## Outcome(s)
 

--- a/docs/public/specifications/tests/Zone-TP/zone11.md
+++ b/docs/public/specifications/tests/Zone-TP/zone11.md
@@ -96,8 +96,8 @@ same specification.
 
 2. Create an empty set of pairs of IP addresses and strings, "SPF-Policies".
 
-3. Obtain the set of name server IP addresses using [Method4] and [Method5]
-   ("Name Server IP").
+3. Retrieve all name server IP addresses for *Child Zone* using methods
+   [Get-Del-NS-IPs] and [Get-Zone-NS-IPs] ("Name Server IP").
 
 4. For each name server in *Name Server IP* do:
 
@@ -223,9 +223,6 @@ None.
   name consists of a single label (ignoring the empty label after the final
   dot).
 
-* "using Method" - The term is used when data is fetched using the defined
-  [Method][Methods].
-
 [Argument list]:                        ../ArgumentsForTestCaseMessages.md
 [argument]:                             #terminology
 [concatenate]:                          #terminology
@@ -237,12 +234,11 @@ None.
 [Dotless Domains Considered Harmful]:   https://www.iab.org/documents/correspondence-reports-documents/2013-2/iab-statement-dotless-domains-considered-harmful/
 [Email Domain]:                         #terminology
 [ERROR]:                                ../SeverityLevelDefinitions.md#error
+[Get-Del-NS-IPs]:                       ../MethodsV2.md#method-get-delegation-ns-ip-addresses
+[Get-Zone-NS-IPs]:                      ../MethodsV2.md#method-get-zone-ns-ip-addresses
 [INFO]:                                 ../SeverityLevelDefinitions.md#info
 [Internet Architecture Board]:          https://www.iab.org/
 [Message Tag Specification]:            MessageTagSpecification.md
-[Method4]:                              ../Methods.md#method-4-obtain-glue-address-records-from-parent
-[Method5]:                              ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
-[Methods]:                              ../Methods.md
 [Null SPF]:                             #terminology
 [NOTICE]:                               ../SeverityLevelDefinitions.md#notice
 [online SPF syntax validator]:          https://vamsoft.com/support/tools/spf-syntax-validator


### PR DESCRIPTION
## Purpose

This PR amends the specification for Zone11 so that different message tags of different severity levels are output if Zonemaster is run on the root zone, a TLD zone or a zone inside .arpa. It also cleans up some rough edges and migrates to MethodsV2.

## Context

See #1256.

## Changes

- Root zones, TLD zones and zones inside .arpa are tested differently: an INFO is output if no SPF or a null SPF is found, and a message tag of higher level is output if a non-null SPF is found.
- Use MethodsV2 instead of legacy Methods.
- Miscellaneous small rewordings

### Breaking message tag changes

This PR changes the arguments to the following existing message tags:

| Tag                              | Old arguments | New arguments |
|:---------------------------------|:--------------|:--------------|
| Z11_DIFFERENT_SPF_POLICIES_FOUND | ns_ip_list    | ns_list       |

This PR replaces the following message tags with new tags:

| Old tag                   | Old tag arguments | New tag                  | New tag arguments |
|:--------------------------|:------------------|:-------------------------|:------------------|
| Z11_SPF1_MULTIPLE_RECORDS | ns_ip_list        | Z11_SPF_MULTIPLE_RECORDS | ns_list           |
| Z11_SPF1_SYNTAX_ERROR     | ns_ip_list        | Z11_SPF_SYNTAX_ERROR     | ns_list           |
| Z11_SPF1_SYNTAX_OK        | ns_ip_list        | Z11_SPF_SYNTAX_OK        | ns_list           |

## How to test this PR

Review.
