### PR TITLE
Updates Zonemaster-LDNS build instructions

### DIFF
--- a/docs/internal/maintenance/ReleaseProcess-create-docker-image.md
+++ b/docs/internal/maintenance/ReleaseProcess-create-docker-image.md
@@ -95,7 +95,7 @@ git -C zonemaster-cli checkout origin/master
 ### Make sure repositories are clean and create `Makefile` in all three repositories
 
 ```sh
-(cd zonemaster-ldns; git submodule update; git clean -dfx; git reset --hard; perl Makefile.PL)
+(cd zonemaster-ldns; git submodule deinit -f ldns; git clean -dfx; git reset --hard; perl Makefile.PL)
 ```
 ```sh
 (cd zonemaster-engine; git clean -dfx; git reset --hard; perl Makefile.PL)

--- a/docs/internal/maintenance/ReleaseProcess-create-test-distribution.md
+++ b/docs/internal/maintenance/ReleaseProcess-create-test-distribution.md
@@ -32,45 +32,46 @@ Set up build system to be used for the test distribution creation. See
 
 Make sure that you have checked out the correct git branch, normally
 the `develop` branch and that your clone is up-to-date.
+```
+git fetch --all
+git branch
+```
+For Zonemaster-LDNS only - empty the submodule area (LDNS):
 
-       git fetch --all
-       git branch
-
-For Zonemaster-LDNS only - check out submodule to the right commit (LDNS):
-
-       git submodule update
-
+```
+git submodule deinit -f ldns
+```
 Make sure your working directory is clean.
-
-       git status --ignored
-
+```
+git status --ignored
+```
 To clean (throw away untracked changes or files):
-
-       git clean -dfx
-       git reset --hard
-
+```
+git clean -dfx
+git reset --hard
+```
 You should usually work in the *develop branch*, and that should be up-to-date
 with the remote *develop branch*. Your working branch:
-
-    git branch -av | grep "^*"
-
+```
+git branch -av | grep "^*"
+```
 All branches called "develop":
-
-    git branch -av --list "*develop"
-
+```
+git branch -av --list "*develop"
+```
 
 ## 4. Generate Makefile, META.yml and others
 
 > This section is not relevant for Zonemaster-GUI.
 
  * For Zonemaster-LDNS:
-
-       perl Makefile.PL --no-ed25519
-
+```
+perl Makefile.PL --no-ed25519
+```
  * For all components except Zonemaster-LDNS:
-
-       perl Makefile.PL
-
+```
+perl Makefile.PL
+```
 > **Note: You can ignore the following warnings:**
 > * Missing META.yml (created by the very same command).
 > * Zonemaster-LDNS: Missing ldns source files (fetched by the very same command).
@@ -84,21 +85,21 @@ All branches called "develop":
 
 Build generated files (if any) and verify that a distribution tarball can be 
 successfully built for each component that is to be updated in this release.
-
-    make all
-
+```
+make all
+```
 For all components, make sure that all files are covered by MANIFEST and/or 
 MANIFEST.SKIP, i.e. no missing or extra files:
-
-    make distcheck
-
+```
+make distcheck
+```
 
 ## 6. Produce distribution tarballs
 
 > This section is not relevant for Zonemaster-GUI.
-
-    make dist
-
+```
+make dist
+```
 
 ## 7. Produce distribution zip file
 

--- a/docs/internal/maintenance/ReleaseProcess-release.md
+++ b/docs/internal/maintenance/ReleaseProcess-release.md
@@ -171,9 +171,9 @@ up-to-date.
 git fetch --all
 git branch
 ```
-Check out the right commit of the submodule (LDNS). Zonemaster-LDNS only.
+Empty the submodule area (LDNS). Zonemaster-LDNS only.
 ```
-git submodule update
+git submodule deinit -f ldns
 ```
 Make sure your working directory is clean.
 ```


### PR DESCRIPTION
## Purpose

When the LDNS submodule has been changed the command `git submodule update` is not enough. This PR updates the instructions in various documents to run `git submodule deinit -f ldns` instead.

## How to test this PR

Review