### PR TITLE
Deprecate yes/no boolean values

### DIFF
--- a/docs/public/configuration/backend.md
+++ b/docs/public/configuration/backend.md
@@ -66,15 +66,23 @@ Available keys: `enable_batch_create`, `enable_user_create`,
 
 Boolean value to enable the `add_batch_job` and `batch_create` methods of the API.
 
-Accepted values: `yes` (or `true`) or `no` (or `false`),
-default to `yes` (enabled).
+Accepted values: `true` or `false` (or `yes` or `no`),
+default to `true` (enabled).
+
+**Deprecated:** The `yes`/`no` values are deprecated and will be rejected in
+v2026.2.
+Use `true`/`false` instead.
 
 ### enable_add_api_user
 
 Boolean value to enable the `add_api_user` and `user_create` method of the API.
 
-Accepted values: `yes` (or `true`) or `no` (or `false`),
-default to `no` (disabled).
+Accepted values: `true` or `false` (or `yes` or `no`),
+default to `false` (disabled).
+
+**Deprecated:** The `yes`/`no` values are deprecated and will be rejected in
+v2026.2.
+Use `true`/`false` instead.
 
 ### enable_batch_create
 


### PR DESCRIPTION
## Purpose

This PR deprecates boolean literals other than `true` and `false` in the config file.

## Context

This harmonizes boolean representation with the RPC API.

## Changes

These changes affect the `RPCAPI.enable_add_batch_job` and `RPCAPI.enable_add_api_user` config properties.

## How to test this PR

N/A