### PR TITLE
Fix link in the public documentation

### DIFF
--- a/docs/public/installation/zonemaster-backend.md
+++ b/docs/public/installation/zonemaster-backend.md
@@ -839,4 +839,4 @@ performance. See [Global cache in Zonemaster-Engine].
 [Zonemaster::GUI installation]:                 zonemaster-gui.md
 [Zonemaster::LDNS]:                             https://github.com/zonemaster/zonemaster-ldns/blob/master/README.md
 [Docker]:                                       https://en.wikipedia.org/wiki/Docker_(software)
-[Using the Backend]:                            ../using/backend/ 
+[Using the Backend]:                            ../using/backend/README.html 

--- a/docs/public/installation/zonemaster-backend.md
+++ b/docs/public/installation/zonemaster-backend.md
@@ -839,4 +839,4 @@ performance. See [Global cache in Zonemaster-Engine].
 [Zonemaster::GUI installation]:                 zonemaster-gui.md
 [Zonemaster::LDNS]:                             https://github.com/zonemaster/zonemaster-ldns/blob/master/README.md
 [Docker]:                                       https://en.wikipedia.org/wiki/Docker_(software)
-[Using the Backend]:                            ../using/backend/README.html 
+[Using the Backend]:                            ../using/backend/README.md


### PR DESCRIPTION
## Purpose

Fixed a link causing a display bug on doc.zonemaster.[fr,net]

## Context

when browsing the documentation on [zonemaster-backend](https://doc.zonemaster.net/latest/installation/zonemaster-backend.html) if you click on link "Using the Backend" (in overview section) you are redirected to the good place but a lot of things are displayed strangely.
When you consult the documentation on [zonemaster-backend](https://doc.zonemaster.net/latest/installation/zonemaster-backend.html), if you click on the "Using the backend" link (in the overview section), you are redirected to the right place, but many things are displayed strangely.

## Changes

Set the link to "README.html" instead of the directory.

