### PR TITLE
Documentation: have Debian/Ubuntu users install libcrypt-dev explicitly

### DIFF
--- a/docs/public/installation/zonemaster-engine.md
+++ b/docs/public/installation/zonemaster-engine.md
@@ -91,7 +91,7 @@ Using pre-built packages is the preferred method for Debian and Ubuntu.
 2) Install dependencies from binary packages:
 
    ```sh
-   sudo apt install autoconf automake build-essential cpanminus libclass-accessor-perl libclone-perl libdevel-checklib-perl libemail-valid-perl libextutils-pkgconfig-perl libfile-sharedir-perl libfile-slurp-perl libidn2-dev libintl-perl libio-socket-inet6-perl liblist-compare-perl liblist-moreutils-perl liblocale-po-perl liblog-any-perl libmail-spf-perl libmime-base32-perl libmodule-find-perl libmodule-install-perl libmodule-install-xsutil-perl libnet-dns-perl libnet-ip-xs-perl libpod-coverage-perl libreadonly-perl libssl-dev libsub-override-perl libtest-differences-perl libtest-exception-perl libtest-fatal-perl libtest-nowarnings-perl libtest-pod-perl libtext-csv-perl libyaml-libyaml-perl libtool m4
+   sudo apt install autoconf automake build-essential cpanminus libclass-accessor-perl libclone-perl libcrypt-dev libdevel-checklib-perl libemail-valid-perl libextutils-pkgconfig-perl libfile-sharedir-perl libfile-slurp-perl libidn2-dev libintl-perl libio-socket-inet6-perl liblist-compare-perl liblist-moreutils-perl liblocale-po-perl liblog-any-perl libmail-spf-perl libmime-base32-perl libmodule-find-perl libmodule-install-perl libmodule-install-xsutil-perl libnet-dns-perl libnet-ip-xs-perl libpod-coverage-perl libreadonly-perl libssl-dev libsub-override-perl libtest-differences-perl libtest-exception-perl libtest-fatal-perl libtest-nowarnings-perl libtest-pod-perl libtext-csv-perl libyaml-libyaml-perl libtool m4
    ```
 
 3) Install Zonemaster::LDNS and Zonemaster::Engine.


### PR DESCRIPTION
## Purpose

This PR updates the installation instructions for Debian/Ubuntu users looking to install Zonemaster from CPAN.

It adds `libcrypt-dev` to the list of packages installed in the long `apt-get` command line appearing in the instructions.

That package used to be automatically pulled in when installing the other prerequisites (presumably Perl), but this is no longer the case with the latest release of Ubuntu, version 26.04 (Resolute Raccoon).

Failure to install that package could cause errors like these to happen when trying to build Zonemaster::LDNS:

```
In file included from /usr/lib/x86_64-linux-gnu/perl/5.40/CORE/op.h:700,
                 from /usr/lib/x86_64-linux-gnu/perl/5.40/CORE/perl.h:4549,
                 from include/LDNS.h:2,
                 from src/LDNS.xs:1:
/usr/lib/x86_64-linux-gnu/perl/5.40/CORE/reentr.h:126:16: fatal error: crypt.h: No such file or directory
  126 | #      include <crypt.h>
      |                ^~~~~~~~~
```

## Context

Updating CI to build nightly packages for Ubuntu 26.04 LTS (Resolute Raccoon).

## Changes

 * Document explicit dependency on `libcrypt-dev`.

## How to test this PR

N/A.