### PR TITLE
Drop unused log directory on Rocky

### DIFF
--- a/docs/public/configuration/backend-environment-variables.md
+++ b/docs/public/configuration/backend-environment-variables.md
@@ -7,7 +7,9 @@
 
 ## Variables used by RPCAPI daemon only
 
-* `ZM_BACKEND_RPCAPI_LOGLEVEL`: Configure the log level, `trace` by default.
+* `ZM_BACKEND_RPCAPI_LOGLEVEL`: The threshold for emitting log entries. Default:
+  info.
+
   Accepted values are:
   * `trace`
   * `debug`
@@ -18,9 +20,15 @@
   * `critical` (also accepted: `crit`, `fatal`)
   * `alert`
   * `emergency`
-* `ZM_BACKEND_RPCAPI_LOGJSON`: Setting it to any truthy value (non-empty
-  string or non-zero number) will configure the logger to log in JSON format,
-  undefined by default.
+
+* `ZM_BACKEND_RPCAPI_LOGJSON`: A [boolean]. When true, logs are written in JSON
+  format.
+
+* `ZM_BACKEND_RPCAPI_NO_LOGPID`: A [boolean]. Controls the inclusion of PID in
+  log entries.
+
+* `ZM_BACKEND_RPCAPI_NO_LOGTIMESTAMP`: A [boolean]. Controls the inclusion of
+  timestamp log entries.
 
 ## Variables used by unit test scripts
 
@@ -30,6 +38,16 @@
   * `PostgreSQL`
   * `MySQL`
 
-* `ZONEMASTER_RECORD`: Setting it to any truthy value (non-empty string or
-  non-zero number) will record the data from the test to a file. Otherwise the
-  data is loaded from a file.
+* `ZONEMASTER_RECORD`: A [boolean]. When true, data is retrieved over the
+  network and persisted to a data file. When false, data is retrieved from a
+  data file.
+
+## Boolean variables
+
+For boolean environment variables two values are falsy: the empty string, and
+the string `0`. Every other value is truthy. An unset boolean environment
+variable is false by default.
+
+
+
+[Boolean]: #boolean-variables

--- a/docs/public/installation/zonemaster-backend.md
+++ b/docs/public/installation/zonemaster-backend.md
@@ -24,7 +24,7 @@
   * [5.5 Post-installation (FreeBSD)](#55-post-installation-freebsd)
 * [6. Post-installation][Post-installation]
   * [6.1 Smoke test](#61-smoke-test)
-  * [6.2 Troubleshooting installation](#62-troubleshooting-installation)
+  * [6.2 Troubleshooting](#62-troubleshooting)
   * [6.3 What to do next?](#63-what-to-do-next)
 * [7. Installation with MariaDB](#7-installation-with-mariadb)
   * [7.1 MariaDB (Rocky Linux)][MariaDB instructions Rocky Linux]
@@ -116,10 +116,11 @@ Install files to their proper locations:
 cd `perl -MFile::ShareDir=dist_dir -E 'say dist_dir("Zonemaster-Backend")'`
 sudo install -v -m 755 -d /etc/zonemaster
 sudo install -v -m 640 -g zonemaster ./backend_config.ini /etc/zonemaster/
-sudo install -v -m 775 -g zonemaster -d /var/log/zonemaster
 sudo install -v -m 644 ./tmpfiles.conf /usr/lib/tmpfiles.d/zonemaster.conf
 sudo install -v -m 644 -Z ./zm-rpcapi.service /etc/systemd/system/
+sudo install -v -m 644 -Z ./zm-rpcapi.service.conf /etc/sysconfig/zm-rpcapi
 sudo install -v -m 644 -Z ./zm-testagent.service /etc/systemd/system/
+sudo install -v -m 644 -Z ./zm-testagent.service.conf /etc/sysconfig/zm-testagent
 ```
 
 ### 3.2 Database engine installation (Rocky Linux)
@@ -470,11 +471,21 @@ The command is expected to immediately print out a testid,
 followed by a percentage ticking up from 0% to 100%.
 Once the number reaches 100% a JSON object is printed and zmtest terminates.
 
-### 6.2 Troubleshooting installation
+### 6.2 Troubleshooting
 
-If you have any issue with installation, and installed with `cpanm`, redo the
-installation above but without the `--notest` and with the `--verbose` option.
-Installation will take longer time.
+* If you have any issue while installing using `cpanm`, redo the installation
+  above but without the `--notest` and with the `--verbose` option. Installation
+  will take longer time.
+
+* If you have any issue with zm-rpcapi or zm-testagent not starting on Rocky
+  Linux, check the service status and logs.
+
+  ```sh
+  systemctl status zm-rpcapi
+  systemctl status zm-testagent
+  journalctl -xe -u zm-rpcapi
+  journalctl -xe -u zm-testagent
+  ```
 
 ### 6.3. What to do next?
 


### PR DESCRIPTION
All logs are sent to journald on Rocky

## Purpose

When all logs are sent to journald we don't need to create a directory under /var/log.

## Context

With zonemaster/zonemaster-backend#1244:
* The log directory is obsoleted.
* ~~Two newly introduced systemd environment files need to be installed.~~

## Changes

The creation of /var/log/zonemaster is removed from the Backend installation instruction for Rocky. 

## How to test this PR

Install Backend and verify that both zm-rpcapi and zm-testagent can start.