### PR TITLE
Migration guide for Backend 12.1.0

### DIFF
--- a/docs/public/SUMMARY.md
+++ b/docs/public/SUMMARY.md
@@ -23,6 +23,7 @@
         - [v9.0.0](upgrading/backend/upgrade_zonemaster_backend_ver_9.0.0.md)
         - [v11.1.0](upgrading/backend/upgrade_zonemaster_backend_ver_11.1.0.md)
         - [v11.2.0](upgrading/backend/upgrade_zonemaster_backend_ver_11.2.0.md)
+        - [v12.0.0](upgrading/backend/upgrade_zonemaster_backend_ver_12.0.0.md)
 - [Configuration](configuration/README.md)
     - [Profiles](configuration/profiles.md)
     - [Global Cache](configuration/global-cache.md)

--- a/docs/public/upgrading/backend.md
+++ b/docs/public/upgrading/backend.md
@@ -53,7 +53,8 @@ Current Zonemaster::Backend version | Link to instructions | Comments
  8.0.0 ≤ version < 9.0.0            | [Upgrade to 9.0.0]   |
  9.0.0 ≤ version < 11.1.0           | [Upgrade to 11.1.0]  |
  11.1.0 ≤ version < 11.2.0          | [Upgrade to 11.2.0]  |
- 11.2.0 ≤ version                   | -                    | No special steps needed for upgrade
+ 11.2.0 ≤ version < 12.0.0          | [Upgrade to 12.0.0]  |
+ 12.0.0 ≤ version                   | -                    | No special steps needed for upgrade
 
 ## 4. Find current version
 
@@ -75,4 +76,5 @@ perl -E 'use Zonemaster::Backend; say $Zonemaster::Backend::VERSION;'
 [Upgrade to 9.0.0]:          backend/upgrade_zonemaster_backend_ver_9.0.0.md
 [Upgrade to 11.1.0]:         backend/upgrade_zonemaster_backend_ver_11.1.0.md
 [Upgrade to 11.2.0]:         backend/upgrade_zonemaster_backend_ver_11.2.0.md
+[Upgrade to 12.0.0]:         backend/upgrade_zonemaster_backend_ver_12.0.0.md
 [Zonemaster::Engine installation]: ../installation/zonemaster-engine.md

--- a/docs/public/upgrading/backend/upgrade_zonemaster_backend_ver_12.0.0.md
+++ b/docs/public/upgrading/backend/upgrade_zonemaster_backend_ver_12.0.0.md
@@ -1,0 +1,15 @@
+# Upgrade to 12.0.0
+
+## Upgrading the database
+
+If your Zonemaster database was created by a Zonemaster-Backend version lower
+than v12.0.0, and not upgraded, use the following instructions.
+
+> You may need to run these command with root privileges.
+
+### Migration script
+
+```sh
+cd `perl -MFile::ShareDir -le 'print File::ShareDir::dist_dir("Zonemaster-Backend")'`
+perl patch/patch_db_schema_version_1.pl
+```

--- a/docs/public/upgrading/backend/upgrade_zonemaster_backend_ver_12.0.0.md
+++ b/docs/public/upgrading/backend/upgrade_zonemaster_backend_ver_12.0.0.md
@@ -10,6 +10,5 @@ than v12.0.0, and not upgraded, use the following instructions.
 ### Migration script
 
 ```sh
-cd `perl -MFile::ShareDir -le 'print File::ShareDir::dist_dir("Zonemaster-Backend")'`
-perl patch/patch_db_schema_version_1.pl
+perl `perl -MFile::ShareDir -le 'print File::ShareDir::dist_dir("Zonemaster-Backend")'`/patch/patch_db_schema_version_1.pl
 ```


### PR DESCRIPTION
## Purpose

This PR adds an upgrade guide for zonemaster/zonemaster-backend#1234.

## Context

Part of implementation for zonemaster/zonemaster-backend#1234.
The other part is in zonemaster/zonemaster-backend#1241.

 zonemaster/zonemaster-backend#1241.

## Changes

A new upgrade guide document was added and referenced.

## How to test this PR

This should be tested together with zonemaster/zonemaster-backend#1241.

## Errata

The Backend version in this PR should have been v12.1.0 instead of v12.0.0. This PR is corrected through PR #1509. The title of this PR has been corrected.
