### PR TITLE
Adds CBOR as dependency for Zonemaster::Engine

### DIFF
--- a/docs/public/installation/zonemaster-engine.md
+++ b/docs/public/installation/zonemaster-engine.md
@@ -137,7 +137,7 @@ Using pre-built packages is the preferred method for Debian and Ubuntu.
 5) Install dependencies from binary packages:
 
    ```sh
-   pkg install devel/gmake dns/ldns libidn2 p5-App-cpanminus p5-Class-Accessor p5-Clone p5-Devel-CheckLib p5-Email-Valid p5-ExtUtils-PkgConfig p5-File-ShareDir p5-File-Slurp p5-IO-Socket-INET6 p5-List-Compare p5-List-MoreUtils p5-Locale-libintl p5-Locale-PO p5-Log-Any p5-Mail-SPF p5-MIME-Base32 p5-Module-Find p5-Module-Install p5-Module-Install-XSUtil p5-Net-DNS p5-Net-IP-XS p5-Pod-Coverage p5-Readonly p5-Sub-Override p5-Test-Differences p5-Test-Exception p5-Test-Fatal p5-Test-NoWarnings p5-Test-Pod p5-Text-CSV p5-YAML-LibYAML
+   pkg install devel/gmake dns/ldns libidn2 p5-CBOR-XS p5-App-cpanminus p5-Class-Accessor p5-Clone p5-Devel-CheckLib p5-Email-Valid p5-ExtUtils-PkgConfig p5-File-ShareDir p5-File-Slurp p5-IO-Socket-INET6 p5-List-Compare p5-List-MoreUtils p5-Locale-libintl p5-Locale-PO p5-Log-Any p5-Mail-SPF p5-MIME-Base32 p5-Module-Find p5-Module-Install p5-Module-Install-XSUtil p5-Net-DNS p5-Net-IP-XS p5-Pod-Coverage p5-Readonly p5-Sub-Override p5-Test-Differences p5-Test-Exception p5-Test-Fatal p5-Test-NoWarnings p5-Test-Pod p5-Text-CSV p5-YAML-LibYAML
    ```
 
 6) Install Zonemaster::LDNS:


### PR DESCRIPTION
## Purpose

PR https://github.com/zonemaster/zonemaster-engine/pull/1517 adds CBOR as a new dependency. This PR updates the installation instruction to include CBOR (CBOR::XS) as a dependency.

*Currently this PR only fixes the installation instruction for FreeBSD.*

## Context

https://github.com/zonemaster/zonemaster-engine/pull/1517

## How to test this PR

When installation Zonemaster::Engine with `cpanm` after following the these instruction on a clean system, `cpanm` should say that CBOR::XS is installed, e.g.
```
Checking if you have CBOR::XS 0 ... Yes (1.3)
```
