### PR TITLE
Doc (Rocky): remove ref to non-existent files

### DIFF
--- a/docs/public/installation/zonemaster-backend.md
+++ b/docs/public/installation/zonemaster-backend.md
@@ -118,9 +118,7 @@ sudo install -v -m 755 -d /etc/zonemaster
 sudo install -v -m 640 -g zonemaster ./backend_config.ini /etc/zonemaster/
 sudo install -v -m 644 ./tmpfiles.conf /usr/lib/tmpfiles.d/zonemaster.conf
 sudo install -v -m 644 -Z ./zm-rpcapi.service /etc/systemd/system/
-sudo install -v -m 644 -Z ./zm-rpcapi.service.conf /etc/sysconfig/zm-rpcapi
 sudo install -v -m 644 -Z ./zm-testagent.service /etc/systemd/system/
-sudo install -v -m 644 -Z ./zm-testagent.service.conf /etc/sysconfig/zm-testagent
 ```
 
 ### 3.2 Database engine installation (Rocky Linux)


### PR DESCRIPTION
## Purpose
Removes a reference to non-existent files in the installation instructions documentation for Rocky Linux.

## Context
The referenced files were inadvertently introduced by #1489 which was related to a transient commit (later removed) from zonemaster/zonemaster-backend#124, so they do not exist anymore.

## Changes
Removes 2 lines from the documentation that reference the non-existent files.
