### PR TITLE
Updates installation instructions to match FreeBSD 15

### DIFF
--- a/docs/public/installation/zonemaster-backend.md
+++ b/docs/public/installation/zonemaster-backend.md
@@ -587,7 +587,7 @@ sed -i '' '/[[:<:]]engine[[:>:]]/ s/=.*/= MySQL/' /usr/local/etc/zonemaster/back
 Install, configure and start database engine (and Perl bindings):
 
 ```sh
-pkg install mysql80-server p5-DBD-mysql
+pkg install mysql84-server p5-DBD-mysql
 ```
 
 ```sh

--- a/docs/public/installation/zonemaster-engine.md
+++ b/docs/public/installation/zonemaster-engine.md
@@ -110,12 +110,24 @@ Using pre-built packages is the preferred method for Debian and Ubuntu.
 
 2) Update list of package repositories:
 
-   Create the file `/usr/local/etc/pkg/repos/FreeBSD.conf` with the
-   following content, unless it is already updated:
+   Create the file `/usr/local/etc/pkg/repos/FreeBSD.conf` with the following
+   content, unless it is already updated, to ensure latest updates:
+
+   FreeBSD 14:
 
    ```
    FreeBSD: {
-   url: "pkg+http://pkg.FreeBSD.org/${ABI}/latest",
+     url: "pkg+http://pkg.FreeBSD.org/${ABI}/latest",
+   }
+   ```
+
+   FreeBSD 15:
+   ```
+   FreeBSD-ports: {
+     url: "pkg+https://pkg.FreeBSD.org/${ABI}/latest"
+   }
+   FreeBSD-ports-kmods: {
+     url: "pkg+https://pkg.FreeBSD.org/${ABI}/kmods_latest_${VERSION_MINOR}"
    }
    ```
 

--- a/docs/public/installation/zonemaster-engine.md
+++ b/docs/public/installation/zonemaster-engine.md
@@ -149,19 +149,13 @@ Using pre-built packages is the preferred method for Debian and Ubuntu.
 5) Install dependencies from binary packages:
 
    ```sh
-   pkg install devel/gmake dns/ldns libidn2 p5-App-cpanminus p5-CBOR-XS p5-Class-Accessor p5-Clone p5-Devel-CheckLib p5-Email-Valid p5-ExtUtils-PkgConfig p5-File-ShareDir p5-File-Slurp p5-IO-Socket-INET6 p5-List-Compare p5-List-MoreUtils p5-Locale-libintl p5-Locale-PO p5-Log-Any p5-Mail-SPF p5-MIME-Base32 p5-Module-Find p5-Module-Install p5-Module-Install-XSUtil p5-Net-DNS p5-Net-IP-XS p5-Pod-Coverage p5-Readonly p5-Sub-Override p5-Test-Differences p5-Test-Exception p5-Test-Fatal p5-Test-NoWarnings p5-Test-Pod p5-Text-CSV p5-YAML-LibYAML
+   pkg install devel/gmake libidn2 p5-App-cpanminus p5-CBOR-XS p5-Class-Accessor p5-Clone p5-Devel-CheckLib p5-Email-Valid p5-ExtUtils-PkgConfig p5-File-ShareDir p5-File-Slurp p5-IO-Socket-INET6 p5-List-Compare p5-List-MoreUtils p5-Locale-libintl p5-Locale-PO p5-Log-Any p5-Mail-SPF p5-MIME-Base32 p5-Module-Find p5-Module-Install p5-Module-Install-XSUtil p5-Net-DNS p5-Net-IP-XS p5-Pod-Coverage p5-Readonly p5-Sub-Override p5-Test-Differences p5-Test-Exception p5-Test-Fatal p5-Test-NoWarnings p5-Test-Pod p5-Text-CSV p5-YAML-LibYAML
    ```
 
 6) Install Zonemaster::LDNS:
 
    ```sh
-   cpanm --notest --configure-args="--no-internal-ldns" Zonemaster::LDNS
-   ```
-
-7) Install Zonemaster::Engine:
-
-   ```sh
-   cpanm --notest Zonemaster::Engine
+   cpanm --notest Zonemaster::LDNS Zonemaster::Engine
    ```
 
 ## Post-installation sanity check


### PR DESCRIPTION
## Purpose

This PR updates the installation instruction to match changes in FreeBSD 15 (compared to previous versions).

It also changes from external to internal LDNS for FreeBSD since the FreeBSD package of LDNS was not updated to latest version at the time of release testing. Internal LDNS is what is normally used for Zonemaster. FreeBSD was the only exception.

## How to test this PR

Review and make a test installation.