### PR TITLE
Add build environment document for Rocky Linux

### DIFF
--- a/docs/internal/distrib-testing/README.md
+++ b/docs/internal/distrib-testing/README.md
@@ -2,18 +2,17 @@
 
 ## Overview
 
-The build environment is used for several purposes, but the purpose
-is not for the actual installation of Zonemaster. For the installation
-the normal installation instructions for users should be used. In most
-cases, if you create a build environment you usually do not install
-Zonemaster on that.
+The build environment is used for several purposes, but not for the purpose
+of installing Zonemaster. There is the standard user installation instructions
+for that. If you create a build environment, in most cases you do not
+install Zonemaster there too.
 
 * When testing the installation instructions for users you should avoid
-  to do that from a build environment.
+  doing that from a build environment.
 * For the use cases below, your should in most cases make sure that
-  you use the develop branch.
-* You should probably read this file
-  [from the develop branch][BuildEnvironmentPreparation], not master
+  you use the `develop` branch.
+* Similarly, you should probably read this file
+  [from the develop branch][BuildEnvironmentPreparation], not `master`
   branch to get the latest changes.
 
 ## Use cases
@@ -29,10 +28,9 @@ Zonemaster on that.
 7. Check for broken, internal links in mdBook as part of release.
 8. Development work.
 
-There could be more use cases.
+Note: there could be more use cases.
 
 1\) Zonemaster-LDNS, Zonemaster-Engine, Zonemaster-CLI and Zonemaster-Backend.
-
 
 ### Building Perl CPAN packages
 
@@ -44,7 +42,7 @@ Build environments:
 * [Debian build environment]
 * [FreeBSD build environment]
 * [Ubuntu build environment]
-* Rocky-Linux environment (TBD)
+* [Rocky Linux build environment]
 
 ### GUI zip distribution
 
@@ -79,6 +77,7 @@ For use case 8, install an environment as for use cases
 [BuildEnvironmentPreparation]:        https://github.com/zonemaster/zonemaster/blob/develop/docs/internal/distrib-testing/README.md
 [Debian build environment]:           Debian-build-environment.md
 [FreeBSD build environment]:          FreeBSD-build-environment.md
+[Rocky Linux build environment]:      RockyLinux-build-environment.md
 [Ubuntu build environment]:           Ubuntu-build-environment.md
 [Ubuntu Node.js environment]:         Ubuntu-Node.js-build-environment.md
 [Create Test Distribution]:           ../maintenance/ReleaseProcess-create-test-distribution.md

--- a/docs/internal/distrib-testing/RockyLinux-build-environment.md
+++ b/docs/internal/distrib-testing/RockyLinux-build-environment.md
@@ -1,0 +1,76 @@
+# Rocky Linux Build Environment
+
+## Table of contents
+
+* [Introduction](#introduction)
+* [Preparation](#preparation)
+* [Installation for package building](#installation-for-package-building)
+* [Translation work](#translation-work)
+* [Installation for mdBook](#installation-for-mdbook)
+
+## Introduction
+
+These are instructions for creating a build environment for Zonemaster components
+based on Perl. This is not meant as instructions for installing Zonemaster
+itself. You should normally use the version of these instructions found in the
+develop branch.
+
+This instruction is for creating it on Rocky Linux. See other files for other OSs.
+
+## Preparation
+
+1. Make a clean installation of [Rocky Linux].
+
+2. Update the package database.
+
+   ```sh
+   sudo dnf update
+   ```
+
+## Installation for package building
+
+1. Install dependencies and tools:
+
+   ```sh
+   sudo dnf install git cpanminus gettext autoconf automake libtool perl-Module-Install
+   ```
+
+2. Clone 'develop' branch from all Zonemaster repositories except GUI:
+
+   ```sh
+   git clone -b develop https://github.com/zonemaster/zonemaster.git
+   for d in ldns engine cli backend; do git clone -b develop https://github.com/zonemaster/zonemaster-$d.git; done
+   ```
+
+## Translation work
+
+Install for translation (handling PO files), only needed if PO files are to be
+handled.
+
+* Follow "Software preparation" in [Instructions for translators] for
+  Rocky Linux (usually use the version in develop branch).
+
+## Installation for mdBook
+
+> Note that building with Cargo below can be time consuming.
+
+Needed for release process:
+
+   ```
+   sudo dnf install rustc
+   ```
+   ```
+   cargo install mdbook-linkcheck
+   ```
+Needed to build the mdBook (not part of release process):
+
+   ```
+   sudo dnf install rustc
+   ```
+   ```
+   cargo install mdbook mdbook-linkcheck
+   ```
+
+
+[Instructions for translators]:            ../maintenance/Instructions-for-translators.md#software-preparation
+[Rocky Linux]:                             https://rockylinux.org/


### PR DESCRIPTION
## Purpose

This PR proposes to add an internal document related to making a build environment in Rocky Linux.

## Context

v2026.1 release

## Changes

- Add build environment document for Rocky Linux
- Few editorial changes

## How to test this PR

Review. Try to build a component with the proposed steps on a fresh Rocky Linux machine.