### PR TITLE
Corrects version in Backend migration guide from v12.0.0 to v12.1.0

### DIFF
--- a/docs/public/SUMMARY.md
+++ b/docs/public/SUMMARY.md
@@ -23,7 +23,7 @@
         - [v9.0.0](upgrading/backend/upgrade_zonemaster_backend_ver_9.0.0.md)
         - [v11.1.0](upgrading/backend/upgrade_zonemaster_backend_ver_11.1.0.md)
         - [v11.2.0](upgrading/backend/upgrade_zonemaster_backend_ver_11.2.0.md)
-        - [v12.0.0](upgrading/backend/upgrade_zonemaster_backend_ver_12.0.0.md)
+        - [v12.1.0](upgrading/backend/upgrade_zonemaster_backend_ver_12.1.0.md)
 - [Configuration](configuration/README.md)
     - [Profiles](configuration/profiles.md)
     - [Global Cache](configuration/global-cache.md)

--- a/docs/public/upgrading/backend.md
+++ b/docs/public/upgrading/backend.md
@@ -43,18 +43,18 @@ document.
 *When upgrading from an older version than the previous release, apply each
 upgrade instructions one after another.*
 
-Current Zonemaster::Backend version | Link to instructions | Comments
-------------------------------------|----------------------|-----------------------
- version < 1.0.3                    | [Upgrade to 1.0.3]   |
- 1.0.3 ≤ version < 1.1.0            | [Upgrade to 1.1.0]   |
- 1.1.0 ≤ version < 5.0.0            | [Upgrade to 5.0.0]   |
- 5.0.0 ≤ version < 5.0.2            | [Upgrade to 5.0.2]   | For MySQL/MariaDB only
- 5.0.2 ≤ version < 8.0.0            | [Upgrade to 8.0.0]   |
- 8.0.0 ≤ version < 9.0.0            | [Upgrade to 9.0.0]   |
- 9.0.0 ≤ version < 11.1.0           | [Upgrade to 11.1.0]  |
- 11.1.0 ≤ version < 11.2.0          | [Upgrade to 11.2.0]  |
- 11.2.0 ≤ version < 12.0.0          | [Upgrade to 12.0.0]  |
- 12.0.0 ≤ version                   | -                    | No special steps needed for upgrade
+| Current Zonemaster::Backend version (before upgrade) | Link to instructions | Comments                            |
+|------------------------------------------------------|----------------------|-------------------------------------|
+| version < 1.0.3                                      | [Upgrade to 1.0.3]   |                                     |
+| 1.0.3 ≤ version < 1.1.0                              | [Upgrade to 1.1.0]   |                                     |
+| 1.1.0 ≤ version < 5.0.0                              | [Upgrade to 5.0.0]   |                                     |
+| 5.0.0 ≤ version < 5.0.2                              | [Upgrade to 5.0.2]   | For MySQL/MariaDB only              |
+| 5.0.2 ≤ version < 8.0.0                              | [Upgrade to 8.0.0]   |                                     |
+| 8.0.0 ≤ version < 9.0.0                              | [Upgrade to 9.0.0]   |                                     |
+| 9.0.0 ≤ version < 11.1.0                             | [Upgrade to 11.1.0]  |                                     |
+| 11.1.0 ≤ version < 11.2.0                            | [Upgrade to 11.2.0]  |                                     |
+| 11.2.0 ≤ version < 12.1.0                            | [Upgrade to 12.1.0]  |                                     |
+| 12.1.0 ≤ version                                     | -                    | No special steps needed for upgrade |
 
 ## 4. Find current version
 
@@ -67,14 +67,14 @@ available for the user. If so, consider running the command as root or with
 perl -E 'use Zonemaster::Backend; say $Zonemaster::Backend::VERSION;'
 ```
 
-[Installation instructions]: ../installation/zonemaster-backend.md
-[Upgrade to 1.0.3]:          backend/upgrade_zonemaster_backend_ver_1.0.3.md
-[Upgrade to 1.1.0]:          backend/upgrade_zonemaster_backend_ver_1.1.0.md
-[Upgrade to 5.0.0]:          backend/upgrade_zonemaster_backend_ver_5.0.0.md
-[Upgrade to 5.0.2]:          backend/upgrade_zonemaster_backend_ver_5.0.2.md
-[Upgrade to 8.0.0]:          backend/upgrade_zonemaster_backend_ver_8.0.0.md
-[Upgrade to 9.0.0]:          backend/upgrade_zonemaster_backend_ver_9.0.0.md
-[Upgrade to 11.1.0]:         backend/upgrade_zonemaster_backend_ver_11.1.0.md
-[Upgrade to 11.2.0]:         backend/upgrade_zonemaster_backend_ver_11.2.0.md
-[Upgrade to 12.0.0]:         backend/upgrade_zonemaster_backend_ver_12.0.0.md
+[Installation instructions]:       ../installation/zonemaster-backend.md
+[Upgrade to 1.0.3]:                backend/upgrade_zonemaster_backend_ver_1.0.3.md
+[Upgrade to 1.1.0]:                backend/upgrade_zonemaster_backend_ver_1.1.0.md
+[Upgrade to 5.0.0]:                backend/upgrade_zonemaster_backend_ver_5.0.0.md
+[Upgrade to 5.0.2]:                backend/upgrade_zonemaster_backend_ver_5.0.2.md
+[Upgrade to 8.0.0]:                backend/upgrade_zonemaster_backend_ver_8.0.0.md
+[Upgrade to 9.0.0]:                backend/upgrade_zonemaster_backend_ver_9.0.0.md
+[Upgrade to 11.1.0]:               backend/upgrade_zonemaster_backend_ver_11.1.0.md
+[Upgrade to 11.2.0]:               backend/upgrade_zonemaster_backend_ver_11.2.0.md
+[Upgrade to 12.1.0]:               backend/upgrade_zonemaster_backend_ver_12.1.0.md
 [Zonemaster::Engine installation]: ../installation/zonemaster-engine.md

--- a/docs/public/upgrading/backend/upgrade_zonemaster_backend_ver_12.1.0.md
+++ b/docs/public/upgrading/backend/upgrade_zonemaster_backend_ver_12.1.0.md
@@ -1,9 +1,9 @@
-# Upgrade to 12.0.0
+# Upgrade to 12.1.0
 
 ## Upgrading the database
 
 If your Zonemaster database was created by a Zonemaster-Backend version lower
-than v12.0.0, and not upgraded, use the following instructions.
+than v12.1.0, and not upgraded, use the following instructions.
 
 > You may need to run these command with root privileges.
 


### PR DESCRIPTION
## Purpose

In #1491 a Backend migration guide was added, but it was incorrectly given version v12.0.0 when it should have been v12.1.0. This PR corrects the documents of that PR with correct version.

## Context

#1491, https://github.com/zonemaster/zonemaster-backend/pull/1252

## Changes

Correct version is set and one file is renamed.

## How to test this PR

Review.