### PR TITLE
MethodsV2: add UNDEL-MISSING-GLUE-1 scenario

### DIFF
--- a/docs/public/specifications/test-zones/MethodsV2/methodsv2.md
+++ b/docs/public/specifications/test-zones/MethodsV2/methodsv2.md
@@ -684,6 +684,24 @@ different from the in-zone NS record’s, but the sets of IP addresses are equal
   * Both `ns1a` and `ns1b` have A and AAAA records pointing to the same IPv4
     and IPv6 address respectively.
 
+### UNDEL-MISSING-GLUE-1
+Child is delegated to two in-domain name servers but is tested undelegated.
+The undelegated data is consistent with the delegation, except that for one
+name server, the address records are missing.
+
+* Zone: child.undel-missing-glue-1.methodsv2.xa
+  * Delegation:
+    * Child NS:
+      * ns1-2.child.parent.undel-missing-glue-1.methodsv2.xa
+    * Glue:
+      * Address records (A and AAAA) for
+        * ns1-2.child.parent.undel-missing-glue-1.methodsv2.xa
+  * There is an undelegated version of the zone matching undelegated data.
+  * Undelegated data:
+    * ns1.child.parent.good-undel-1.methodsv2.xa
+    * ns2.child.parent.good-undel-1.methodsv2.xa/IPv4
+    * ns2.child.parent.good-undel-1.methodsv2.xa/IPv6
+
 <!-- Links to documents in this repository but outside the public tree must be
 absolute -->
 

--- a/test-zone-data/MethodsV2/README.md
+++ b/test-zone-data/MethodsV2/README.md
@@ -56,6 +56,7 @@
   * [CHILD-NS-CNAME-4](#child-ns-cname-4)
   * [PARENT-NS-CNAME-1](#parent-ns-cname-1)
   * [PARENT-NS-CNAME-2](#parent-ns-cname-2)
+  * [UNDEL-MISSING-GLUE-1](#undel-missing-glue-1)
 
 
 ## Background
@@ -1380,6 +1381,30 @@ child.parent.parent-ns-same-ip-2.methodsv2.xa
 #### Undelegated data
   * (empty)
 
+
+### UNDEL-MISSING-GLUE-1
+
+#### Zone
+
+child.parent.undel-missing-glue-1.methodsv2.xa
+
+#### Methods and expected output
+* Get parent NS names and IP addresses
+  * (empty)
+* Get delegation NS names and IP addresses
+  * ns1.child.parent.undel-missing-glue-1.methodsv2.xa
+  * ns2.child.parent.undel-missing-glue-1.methodsv2.xa/127.40.1.52
+  * ns2.child.parent.undel-missing-glue-1.methodsv2.xa/fda1:b2:c3:0:127:40:1:52
+* Get zone NS names and IP addresses
+  * ns1.child.parent.undel-missing-glue-1.methodsv2.xa/127.40.1.51
+  * ns1.child.parent.undel-missing-glue-1.methodsv2.xa/fda1:b2:c3:0:127:40:1:51
+  * ns2.child.parent.undel-missing-glue-1.methodsv2.xa/127.40.1.52
+  * ns2.child.parent.undel-missing-glue-1.methodsv2.xa/fda1:b2:c3:0:127:40:1:52
+
+#### Undelegated data
+  * ns1.child.parent.undel-missing-glue-1.methodsv2.xa
+  * ns2.child.parent.undel-missing-glue-1.methodsv2.xa/127.40.1.52
+  * ns2.child.parent.undel-missing-glue-1.methodsv2.xa/fda1:b2:c3:0:127:40:1:52
 
 
 <!--

--- a/test-zone-data/MethodsV2/methodsv2.cfg
+++ b/test-zone-data/MethodsV2/methodsv2.cfg
@@ -1699,4 +1699,36 @@ child.parent.parent-ns-same-ip-2.methodsv2.xa:53 {
     file MethodsV2/child.parent.COMMON.methodsv2.xa.zone child.parent.parent-ns-same-ip-2.methodsv2.xa
 }
 
+### UNDEL-MISSING-GLUE-1
+
+# undel-missing-glue-1.methodsv2.xa
+undel-missing-glue-1.methodsv2.xa:53 {
+    bind 127.40.1.31               # ns1
+    bind fda1:b2:c3:0:127:40:1:31  # ns1
+    bind 127.40.1.32               # ns2
+    bind fda1:b2:c3:0:127:40:1:32  # ns2
+    log
+    file MethodsV2/COMMON.methodsv2.xa.zone undel-missing-glue-1.methodsv2.xa
+}
+
+# parent.undel-missing-glue-1.methodsv2.xa
+parent.undel-missing-glue-1.methodsv2.xa:53 {
+    bind 127.40.1.41               # ns1
+    bind fda1:b2:c3:0:127:40:1:41  # ns1
+    bind 127.40.1.42               # ns2
+    bind fda1:b2:c3:0:127:40:1:42  # ns2
+    log
+    file MethodsV2/parent.COMMON.methodsv2.xa.zone parent.undel-missing-glue-1.methodsv2.xa
+}
+
+# child.parent.undel-missing-glue-1.methodsv2.xa
+child.parent.undel-missing-glue-1.methodsv2.xa:53 {
+    bind 127.40.1.51               # ns1
+    bind fda1:b2:c3:0:127:40:1:51  # ns1
+    bind 127.40.1.52               # ns2
+    bind fda1:b2:c3:0:127:40:1:52  # ns2
+    log
+    file MethodsV2/child.parent.COMMON.methodsv2.xa.zone child.parent.undel-missing-glue-1.methodsv2.xa
+}
+
 # EOF

--- a/test-zone-data/MethodsV2/methodsv2.xa.zone
+++ b/test-zone-data/MethodsV2/methodsv2.xa.zone
@@ -425,6 +425,13 @@ ns1		AAAA	fda1:b2:c3:0:127:40:1:31
 ns2		A	127.40.1.32
 ns2		AAAA	fda1:b2:c3:0:127:40:1:32
 
+$ORIGIN undel-missing-glue-1.methodsv2.xa.                   ; Must end with "."
+@		NS	ns1
+@		NS	ns2
+ns1		A	127.40.1.31
+ns1		AAAA	fda1:b2:c3:0:127:40:1:31
+ns2		A	127.40.1.32
+ns2		AAAA	fda1:b2:c3:0:127:40:1:32
 
 
 ; EOF


### PR DESCRIPTION
## Purpose

This PR adds an additional scenario in the MethodsV2 test scenarios called UNDEL-MISSING-GLUE-1. The idea is to test what happens when a zone is tested undelegated, and the undelegated data contains an in-domain name server lacking any sort of glue.

I was able to verify that this scenario triggers the bug I described in zonemaster/zonemaster-engine#1545. It fails on the current state of `develop` as of 2026-08-11 and passes when merging zonemaster/zonemaster-engine#1546 locally.

## Context

Test suite improvement after successful reproduction, then fix of zonemaster/zonemaster-engine#1545.

## Changes

* Add UNDEL-MISSING-GLUE-1 scenario

## How to test this PR

Review.
